### PR TITLE
Disk optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-# EsMeCaTa v0.3.0 (2022-12-10)
+# EsMeCaTa v0.4.0 (2022-12-10)
+
+WARNING:
+* change in intermediary files of `clustering` and `annotation` in order to reduce disk space used by EsMeCaTa and the number of operations performed by the methods.
+* annotation with eggnog-mapper is now the default workflow methods of EsMeCaTa. The previous annotation methods with UniProt has been moved to `annotation_uniprot` and `workflow_uniprot`.
+
+## Add
+
+* Add a new step called `check`, which corresponds to the `proteomes` step of EsMeCaTa without downloading the proteomes. This allows to look at the knowledge associated with the dataset in the UniProt databases.
+
+
+## Fix
+
+
+## Modify
+
+* Modify the intermerdiary files of `clustering` and `annotation` (made with an idea propsoed by @PaulineGHG). This change replaces tsv files, that were created for each observation names. Now they will be created for each taxon instead. This means that observation names with the same taxon will be associated with the same file. This reduces the redundancy of the file and decreases the number of operations made by EsMeCaTa.
+* Modify how the log json files are created so if a run failed, a new log json file is created instead of erasing the previous ones.
+
+# EsMeCaTa v0.3.0 (2023-12-10)
 
 Add a new way to annotate protein clusters using eggnog-mapper. From test on metagenomcis data, it is more accurate than the methods with UniProt.
 Also modify the default option of EsMeCaTa for option with better results on tested data (minimal number of proteomes from 1 to 5 and clustering threshold from 0.95 to 0.5).

--- a/esmecata/__init__.py
+++ b/esmecata/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/__main__.py
+++ b/esmecata/__main__.py
@@ -315,8 +315,8 @@ def main():
             parent_parser_remove_tmp
             ],
         allow_abbrev=False)
-    annotation_parser = subparsers.add_parser(
-        'annotation',
+    annotation_uniprot_parser = subparsers.add_parser(
+        'annotation_uniprot',
         help='Retrieve protein annotations from Uniprot.',
         parents=[
             parent_parser_i_annotation_folder, parent_parser_o, parent_parser_sparql,
@@ -325,15 +325,15 @@ def main():
             ],
         allow_abbrev=False)
     annotation_eggnog_parser = subparsers.add_parser(
-        'annotation_eggnog',
+        'annotation',
         help='Annotate protein clusters using eggnog-mapper.',
         parents=[
             parent_parser_i_annotation_folder, parent_parser_o, parent_parser_eggnog_database,
             parent_parser_c, parent_parser_eggnog_tmp_dir
             ],
         allow_abbrev=False)
-    workflow_parser = subparsers.add_parser(
-        'workflow',
+    workflow_uniprot_parser = subparsers.add_parser(
+        'workflow_uniprot',
         help='Run all esmecata steps (proteomes, clustering and annotation).',
         parents=[
             parent_parser_i_taxon, parent_parser_o, parent_parser_b, parent_parser_c,
@@ -347,8 +347,8 @@ def main():
             ],
         allow_abbrev=False)
     workflow_eggnog_parser = subparsers.add_parser(
-        'workflow_eggnog',
-        help='Run all esmecata steps (proteomes, clustering and annotation_eggnog).',
+        'workflow',
+        help='Run all esmecata steps (proteomes, clustering and annotation with eggnog-mapper).',
         parents=[
             parent_parser_i_taxon, parent_parser_o, parent_parser_eggnog_database,
             parent_parser_b, parent_parser_c, parent_parser_taxadb,
@@ -389,7 +389,7 @@ def main():
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    if args.cmd in ['proteomes', 'annotation', 'workflow', 'workflow_eggnog', 'check']:
+    if args.cmd in ['proteomes', 'annotation_uniprot', 'workflow_uniprot', 'workflow', 'check']:
         if args.sparql is None:
             uniprot_sparql_endpoint = None
         elif args.sparql == 'uniprot':
@@ -397,7 +397,7 @@ def main():
         else:
             uniprot_sparql_endpoint = args.sparql
 
-    if args.cmd in ['proteomes', 'workflow', 'workflow_eggnog', 'check']:
+    if args.cmd in ['proteomes', 'workflow_uniprot', 'workflow', 'check']:
         if args.busco is not None:
             busco_score = 100*args.busco
 
@@ -413,11 +413,11 @@ def main():
                             args.option_bioservices)
     elif args.cmd == 'clustering':
         make_clustering(args.input, args.output, args.cpu, args.threshold_clustering, args.mmseqs_options, args.linclust, args.remove_tmp)
-    elif args.cmd == 'annotation':
+    elif args.cmd == 'annotation_uniprot':
         annotate_proteins(args.input, args.output, uniprot_sparql_endpoint,
                         args.propagate_annotation, args.uniref, args.expression,
                         args.annotation_files, args.option_bioservices)
-    elif args.cmd == 'workflow':
+    elif args.cmd == 'workflow_uniprot':
         perform_workflow(args.input, args.output, busco_score, args.ignore_taxadb_update,
                             args.all_proteomes, uniprot_sparql_endpoint, args.remove_tmp,
                             args.limit_maximal_number_proteomes, args.rank_limit,
@@ -425,10 +425,10 @@ def main():
                             args.linclust, args.propagate_annotation, args.uniref,
                             args.expression, args.minimal_number_proteomes, args.annotation_files,
                             args.update_affiliations, args.option_bioservices)
-    elif args.cmd == 'annotation_eggnog':
+    elif args.cmd == 'annotation':
         annotate_with_eggnog(args.input, args.output, args.eggnog_database, args.cpu,
                              args.eggnog_tmp_dir)
-    elif args.cmd == 'workflow_eggnog':
+    elif args.cmd == 'workflow':
         perform_workflow_eggnog(args.input, args.output, args.eggnog_database, busco_score,
                                 args.ignore_taxadb_update, args.all_proteomes, uniprot_sparql_endpoint,
                                 args.remove_tmp, args.limit_maximal_number_proteomes, args.rank_limit,

--- a/esmecata/__main__.py
+++ b/esmecata/__main__.py
@@ -18,7 +18,7 @@ import os
 import sys
 import time
 
-from esmecata.proteomes import retrieve_proteomes
+from esmecata.proteomes import check_proteomes, retrieve_proteomes
 from esmecata.clustering import make_clustering
 from esmecata.annotation import annotate_proteins
 from esmecata.workflow import perform_workflow, perform_workflow_eggnog
@@ -284,6 +284,17 @@ def main():
         description='valid subcommands:',
         dest='cmd')
 
+    check_parser = subparsers.add_parser(
+        'check',
+        help='Check proteomes associated with taxon in Uniprot Proteomes database.',
+        parents=[
+            parent_parser_i_taxon, parent_parser_o, parent_parser_b,
+            parent_parser_taxadb, parent_parser_all_proteomes, parent_parser_sparql,
+            parent_parser_limit_maximal_number_proteomes, parent_parser_rank_limit,
+            parent_parser_minimal_number_proteomes, parent_parser_update_affiliation,
+            parent_parser_bioservices
+            ],
+        allow_abbrev=False)
     proteomes_parser = subparsers.add_parser(
         'proteomes',
         help='Download proteomes associated with taxon from Uniprot Proteomes.',
@@ -378,7 +389,7 @@ def main():
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
-    if args.cmd in ['proteomes', 'annotation', 'workflow', 'workflow_eggnog']:
+    if args.cmd in ['proteomes', 'annotation', 'workflow', 'workflow_eggnog', 'check']:
         if args.sparql is None:
             uniprot_sparql_endpoint = None
         elif args.sparql == 'uniprot':
@@ -386,12 +397,17 @@ def main():
         else:
             uniprot_sparql_endpoint = args.sparql
 
-    if args.cmd in ['proteomes', 'workflow', 'workflow_eggnog']:
+    if args.cmd in ['proteomes', 'workflow', 'workflow_eggnog', 'check']:
         if args.busco is not None:
             busco_score = 100*args.busco
 
     if args.cmd == 'proteomes':
         retrieve_proteomes(args.input, args.output, busco_score, args.ignore_taxadb_update,
+                            args.all_proteomes, uniprot_sparql_endpoint, args.limit_maximal_number_proteomes,
+                            args.rank_limit, args.minimal_number_proteomes, args.update_affiliations,
+                            args.option_bioservices)
+    if args.cmd == 'check':
+        check_proteomes(args.input, args.output, busco_score, args.ignore_taxadb_update,
                             args.all_proteomes, uniprot_sparql_endpoint, args.limit_maximal_number_proteomes,
                             args.rank_limit, args.minimal_number_proteomes, args.update_affiliations,
                             args.option_bioservices)

--- a/esmecata/__main__.py
+++ b/esmecata/__main__.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/analysis.py
+++ b/esmecata/analysis.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/annotation.py
+++ b/esmecata/annotation.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/annotation.py
+++ b/esmecata/annotation.py
@@ -1301,7 +1301,13 @@ def annotate_proteins(input_folder, output_folder, uniprot_sparql_endpoint,
     duration = endtime - starttime
     uniprot_releases['esmecata_annotation_duration'] = duration
     uniprot_metadata_file = os.path.join(output_folder, 'esmecata_metadata_annotation.json')
-    with open(uniprot_metadata_file, 'w') as ouput_file:
-        json.dump(uniprot_releases, ouput_file, indent=4)
+    if os.path.exists(uniprot_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_annotation' in metadata_file]
+        uniprot_metadata_file = os.path.join(output_folder, 'esmecata_metadata_annotation_{0}.json'.format(len(metadata_files)))
+        with open(uniprot_metadata_file, 'w') as ouput_file:
+            json.dump(uniprot_releases, ouput_file, indent=4)
+    else:
+        with open(uniprot_metadata_file, 'w') as ouput_file:
+            json.dump(uniprot_releases, ouput_file, indent=4)
 
-    logger.info('|EsMeCaTa|annotation| Annotation complete.')
+    logger.info('|EsMeCaTa|annotation| Annotation complete in {0}.'.format(duration))

--- a/esmecata/clustering.py
+++ b/esmecata/clustering.py
@@ -36,21 +36,31 @@ from esmecata.utils import is_valid_path, is_valid_dir
 logger = logging.getLogger(__name__)
 
 
-def compute_stat_clustering(result_folder, stat_file=None):
+def compute_stat_clustering(output_folder, stat_file=None):
     """Compute stat associated to the number of proteome for each taxonomic affiliations.
 
     Args:
-        result_folder (str): pathname to the result folder containing mmseqs results
+        output_folder (str): pathname to the result folder containing mmseqs results
         stat_file (str): pathname to the tsv stat file
 
     Returns:
         clustering_numbers (dict): dict containing observation names (as key) associated with the number of protein clusters
     """
-    clustering_numbers = {}
+    clustering_taxon_id_file = os.path.join(output_folder, 'proteome_tax_id.tsv')
+    result_folder = os.path.join(output_folder, 'computed_threshold')
+
+    proteomes_taxa_names = get_proteomes_tax_name(clustering_taxon_id_file)
+
+    tax_name_clustering_numbers = {}
     for clustering_file in os.listdir(result_folder):
         clustering_file_path = os.path.join(result_folder, clustering_file)
         num_lines = sum(1 for line in open(clustering_file_path))
-        clustering_numbers[clustering_file.replace('.tsv', '')] = num_lines
+        tax_name_clustering_numbers[clustering_file.replace('.tsv', '')] = num_lines
+
+    clustering_numbers = {}
+    for observation_name in proteomes_taxa_names:
+        tax_name = proteomes_taxa_names[observation_name].replace(' ', '_')
+        clustering_numbers[observation_name] = tax_name_clustering_numbers[tax_name]
 
     if stat_file:
         with open(stat_file, 'w') as stat_file_open:
@@ -84,7 +94,7 @@ def create_proteome_representativeness_lineplot(proteome_tax_id_file, computed_t
         for tmp_threshold in np.arange(0, 1.01, 0.025):
             # Compute the number of protein clusters associated with representativeness ratio of tmp_threshold.
             nb_protein_cluster_ratio = len(tmp_df[tmp_df['cluster_ratio']>= tmp_threshold])
-            data.append([obs_name, tax_rank[obs_name], tmp_threshold, nb_protein_cluster_ratio])
+            data.append([obs_name, obs_name, tmp_threshold, nb_protein_cluster_ratio])
 
     df = pd.DataFrame(data, columns=['obs_name', 'rank', 'clust', 'count'])
 
@@ -106,20 +116,20 @@ def create_proteome_representativeness_lineplot_per_taxon_rank(proteome_tax_id_f
         output_folder (str): pathname to the output folder.
     """
     proteome_df = pd.read_csv(proteome_tax_id_file, sep='\t')
-    proteome_df.set_index('observation_name', inplace=True)
-    tax_rank = proteome_df['tax_rank'].to_dict()
-    tax_name = proteome_df['name'].to_dict()
+    proteome_df.set_index('name', inplace=True)
+    tax_ranks = proteome_df['tax_rank'].to_dict()
+    tax_ids = proteome_df['tax_id'].to_dict()
 
     data = []
     for tsv_file in os.listdir(computed_threshold_folder):
-        obs_name = os.path.splitext(tsv_file)[0]
+        tax_name = os.path.splitext(tsv_file)[0].replace('_', ' ')
         tsv_file_path = os.path.join(computed_threshold_folder, tsv_file)
         tmp_df = pd.read_csv(tsv_file_path, sep='\t')
         for tmp_threshold in np.arange(0, 1.01, 0.025):
             nb_protein_cluster_ratio = len(tmp_df[tmp_df['cluster_ratio']>= tmp_threshold])
-            data.append([obs_name, tax_rank[obs_name], tax_name[obs_name], tmp_threshold, nb_protein_cluster_ratio])
+            data.append([tax_name, tax_ranks[tax_name], tax_ids[tax_name], tmp_threshold, nb_protein_cluster_ratio])
 
-    df = pd.DataFrame(data, columns=['obs_name', 'tax_rank', 'tax_name', 'clust', 'count'])
+    df = pd.DataFrame(data, columns=['tax_name', 'tax_rank', 'tax_id', 'clust', 'count'])
 
     for rank in df['tax_rank'].unique():
         tmp_df = df[df['tax_rank']==rank]
@@ -132,24 +142,24 @@ def create_proteome_representativeness_lineplot_per_taxon_rank(proteome_tax_id_f
         plt.clf()
 
 
-def get_proteomes_tax_id(proteomes_taxon_id_file):
+def get_proteomes_tax_name(proteomes_taxon_id_file):
     """ Extract tax_id associated with observation name.
 
     Args:
         proteomes_taxon_id_file (str): pathname to the proteomes_tax_id file.
 
     Returns:
-        annotation_numbers (dict): dict containing observation names (as key) associated with tax ID used for proteomes (as value)
+        proteomes_taxa_names (dict): dict containing observation names (as key) associated with tax name used for proteomes (as value)
     """
-    proteomes_taxa_ids = {}
+    proteomes_taxa_names = {}
     with open(proteomes_taxon_id_file, 'r') as proteome_tax_file:
         csvreader = csv.DictReader(proteome_tax_file, delimiter='\t')
         for line in csvreader:
             observation_name = line['observation_name']
-            tax_id = line['tax_id']
-            proteomes_taxa_ids[observation_name] = tax_id
+            tax_name = line['name']
+            proteomes_taxa_names[observation_name] = tax_name
 
-    return proteomes_taxa_ids
+    return proteomes_taxa_names
 
 def copy_already_clustered_file(output_folder, already_clustered_obs_name, new_observation_name, file_extension='.tsv'):
     """ Copy files from an observation name with the same tax ID than the new ones.
@@ -397,13 +407,13 @@ def make_clustering(proteome_folder, output_folder, nb_cpu, clust_threshold, mms
     with open(proteome_tax_id_pathname, 'r') as proteome_tax_file:
         csvreader = csv.DictReader(proteome_tax_file, delimiter='\t')
         for line in csvreader:
-            observation_name = line['observation_name']
             proteomes = line['proteome'].split(',')
+            tax_name = line['name']
             proteomes_path = [os.path.join(proteome_folder, 'proteomes', proteome+'.faa.gz') for proteome in proteomes]
-            if observation_name not in already_performed_clustering:
-                observation_name_fasta_files[observation_name] = proteomes_path
+            if tax_name not in already_performed_clustering:
+                observation_name_fasta_files[tax_name] = proteomes_path
             else:
-                logger.info('|EsMeCaTa|clustering| Already performed clustering for %s.', observation_name)
+                logger.info('|EsMeCaTa|clustering| Already performed clustering for %s.', tax_name)
 
     is_valid_dir(output_folder)
 
@@ -444,92 +454,74 @@ def make_clustering(proteome_folder, output_folder, nb_cpu, clust_threshold, mms
     else:
         shutil.copyfile(proteome_taxon_id_file, clustering_taxon_id_file)
 
-    proteomes_taxa_ids = get_proteomes_tax_id(proteome_taxon_id_file)
+    proteomes_taxa_names = get_proteomes_tax_name(proteome_taxon_id_file)
 
-    already_clustered_taxon = {}
+    all_tax_names = set(list(proteomes_taxa_names.values()))
 
     # For each OTU run mmseqs easy-cluster on them to found the clusters that have a protein in each proteome of the OTU.
     # We take the representative protein of a cluster if the cluster contains a protein from all the proteomes of the OTU.
     # If this condition is not satisfied the cluster will be ignored.
     # Then a fasta file containing all the representative proteins for each OTU is written in representative_fasta folder.
-    for observation_name in observation_name_fasta_files:
-        proteomes_tax_id = proteomes_taxa_ids[observation_name]
+    for proteomes_tax_name in all_tax_names:
+        # Get proteomes associated with taxon name.
+        observation_name_proteomes = observation_name_fasta_files[proteomes_tax_name]
 
-        # If the proteomes associated with the taxon ID have already been clustered, copy the results.
-        if proteomes_tax_id in already_clustered_taxon:
-            already_clustered_observation_name = already_clustered_taxon[proteomes_tax_id]
-            logger.info('|EsMeCaTa|clustering| Clustering of taxon ID %s already performed with %s.', proteomes_tax_id, already_clustered_observation_name)
+        # Change space with '_' to avoid issue.
+        proteomes_tax_name = proteomes_tax_name.replace(' ', '_')
+        # If the computed threshold file exists, mmseqs has already been run.
+        mmseqs_tmp_cluster = os.path.join(mmseqs_tmp_path, proteomes_tax_name)
+        # Run mmseqs on organism.
+        # Delete previous mmseqs2 run if it exists to avoid overwritting issues.
+        if os.path.exists(mmseqs_tmp_cluster):
+            shutil.rmtree(mmseqs_tmp_cluster)
+        mmseqs_tmp_clustered_tabulated, mmseqs_tmp_representative_fasta, mmseqs_consensus_fasta = run_mmseqs(proteomes_tax_name, observation_name_proteomes, mmseqs_tmp_path, nb_cpu, mmseqs_options, linclust)
 
-            copy_already_clustered_file(cluster_founds_path, already_clustered_observation_name, observation_name)
+        # Extract protein clusters from mmseqs results.
+        cluster_proteomes_output_file = os.path.join(cluster_founds_path, proteomes_tax_name+'.tsv')
+        protein_clusters = extrat_protein_cluster_from_mmseqs(mmseqs_tmp_clustered_tabulated, cluster_proteomes_output_file)
 
-            copy_already_clustered_file(computed_threshold_path, already_clustered_observation_name, observation_name)
+        # Compute proteome representativeness ratio.
+        computed_threshold_file = os.path.join(computed_threshold_path, proteomes_tax_name+'.tsv')
+        number_proteomes, rep_prot_organims, computed_threshold_cluster = compute_proteome_representativeness_ratio(protein_clusters,
+                                                                                                                    observation_name_proteomes, computed_threshold_file)
 
-            copy_already_clustered_file(reference_proteins_path, already_clustered_observation_name, observation_name)
+        # Filter protein cluster for each protein cluster.
+        cluster_proteomes_filtered_output_file = os.path.join(reference_proteins_path, proteomes_tax_name+'.tsv')
+        protein_cluster_to_keeps = filter_protein_cluster(protein_clusters, number_proteomes, rep_prot_organims, computed_threshold_cluster,
+                                                        clust_threshold, cluster_proteomes_filtered_output_file)
 
-            copy_already_clustered_file(reference_proteins_representative_fasta_path, already_clustered_observation_name, observation_name, '.faa')
+        logger.info('|EsMeCaTa|clustering| %d protein clusters kept for %s.', len(protein_cluster_to_keeps), proteomes_tax_name)
 
-            copy_already_clustered_file(reference_proteins_consensus_fasta_path, already_clustered_observation_name, observation_name, '.faa')
+        # Create BioPython records with the representative proteins kept.
+        new_records = [record for record in SeqIO.parse(mmseqs_tmp_representative_fasta, 'fasta') if record.id.split('|')[1] in protein_cluster_to_keeps]
 
-            logger.info('|EsMeCaTa|clustering| Copy clustering results from %s to %s.', already_clustered_observation_name, observation_name)
-
+        # Do not create fasta file when 0 sequences were kept.
+        if len(new_records) > 0:
+            # Create output proteome file for OTU.
+            representative_fasta_file = os.path.join(reference_proteins_representative_fasta_path, proteomes_tax_name+'.faa')
+            SeqIO.write(new_records, representative_fasta_file, 'fasta')
         else:
-            # If the computed threshold file exists, mmseqs has already been run.
-            mmseqs_tmp_cluster = os.path.join(mmseqs_tmp_path, observation_name)
-            observation_name_proteomes = observation_name_fasta_files[observation_name]
-            # Run mmseqs on organism.
-            # Delete previous mmseqs2 run if it exists to avoid overwritting issues.
-            if os.path.exists(mmseqs_tmp_cluster):
-                shutil.rmtree(mmseqs_tmp_cluster)
-            mmseqs_tmp_clustered_tabulated, mmseqs_tmp_representative_fasta, mmseqs_consensus_fasta = run_mmseqs(observation_name, observation_name_proteomes, mmseqs_tmp_path, nb_cpu, mmseqs_options, linclust)
+            logger.info('|EsMeCaTa|clustering| 0 protein clusters %s, no fasta created.', proteomes_tax_name)
+        del new_records
 
-            # Extract protein clusters from mmseqs results.
-            cluster_proteomes_output_file = os.path.join(cluster_founds_path, observation_name+'.tsv')
-            protein_clusters = extrat_protein_cluster_from_mmseqs(mmseqs_tmp_clustered_tabulated, cluster_proteomes_output_file)
+        # Create BioPython records with the consensus proteins kept.
+        consensus_new_records = [record for record in SeqIO.parse(mmseqs_consensus_fasta, 'fasta') if record.id.split('|')[1] in protein_cluster_to_keeps]
 
-            # Compute proteome representativeness ratio.
-            computed_threshold_file = os.path.join(computed_threshold_path, observation_name+'.tsv')
-            number_proteomes, rep_prot_organims, computed_threshold_cluster = compute_proteome_representativeness_ratio(protein_clusters,
-                                                                                                                        observation_name_proteomes, computed_threshold_file)
+        # Do not create fasta file when 0 sequences were kept.
+        if len(consensus_new_records) > 0:
+            # Create output proteome file for OTU.
+            consensus_fasta_file = os.path.join(reference_proteins_consensus_fasta_path, proteomes_tax_name+'.faa')
+            SeqIO.write(consensus_new_records, consensus_fasta_file, 'fasta')
+        else:
+            logger.info('|EsMeCaTa|clustering| 0 protein clusters %s, no fasta created.', proteomes_tax_name)
+        del consensus_new_records
 
-            # Filter protein cluster for each protein cluster.
-            cluster_proteomes_filtered_output_file = os.path.join(reference_proteins_path, observation_name+'.tsv')
-            protein_cluster_to_keeps = filter_protein_cluster(protein_clusters, number_proteomes, rep_prot_organims, computed_threshold_cluster,
-                                                            clust_threshold, cluster_proteomes_filtered_output_file)
-
-            logger.info('|EsMeCaTa|clustering| %d protein clusters kept for %s.', len(protein_cluster_to_keeps), observation_name)
-
-            # Create BioPython records with the representative proteins kept.
-            new_records = [record for record in SeqIO.parse(mmseqs_tmp_representative_fasta, 'fasta') if record.id.split('|')[1] in protein_cluster_to_keeps]
-
-            # Do not create fasta file when 0 sequences were kept.
-            if len(new_records) > 0:
-                # Create output proteome file for OTU.
-                representative_fasta_file = os.path.join(reference_proteins_representative_fasta_path, observation_name+'.faa')
-                SeqIO.write(new_records, representative_fasta_file, 'fasta')
-            else:
-                logger.info('|EsMeCaTa|clustering| 0 protein clusters %s, no fasta created.', observation_name)
-            del new_records
-
-            # Create BioPython records with the consensus proteins kept.
-            consensus_new_records = [record for record in SeqIO.parse(mmseqs_consensus_fasta, 'fasta') if record.id.split('|')[1] in protein_cluster_to_keeps]
-
-            # Do not create fasta file when 0 sequences were kept.
-            if len(consensus_new_records) > 0:
-                # Create output proteome file for OTU.
-                consensus_fasta_file = os.path.join(reference_proteins_consensus_fasta_path, observation_name+'.faa')
-                SeqIO.write(consensus_new_records, consensus_fasta_file, 'fasta')
-            else:
-                logger.info('|EsMeCaTa|clustering| 0 protein clusters %s, no fasta created.', observation_name)
-            del consensus_new_records
-
-            if remove_tmp:
-                shutil.rmtree(mmseqs_tmp_cluster)
-
-            already_clustered_taxon[proteomes_tax_id] = observation_name
+        if remove_tmp:
+            shutil.rmtree(mmseqs_tmp_cluster)
 
     # Compute number of protein clusters kept.
     stat_file = os.path.join(output_folder, 'stat_number_clustering.tsv')
-    compute_stat_clustering(reference_proteins_path, stat_file)
+    compute_stat_clustering(output_folder, stat_file)
     output_figure_file = os.path.join(output_folder, 'representativeness_clustering_ratio.svg')
     create_proteome_representativeness_lineplot(clustering_taxon_id_file, computed_threshold_path, output_figure_file)
 

--- a/esmecata/clustering.py
+++ b/esmecata/clustering.py
@@ -533,7 +533,13 @@ def make_clustering(proteome_folder, output_folder, nb_cpu, clust_threshold, mms
     duration = endtime - starttime
     clustering_metadata['esmecata_clustering_duration'] = duration
     clustering_metadata_file = os.path.join(output_folder, 'esmecata_metadata_clustering.json')
-    with open(clustering_metadata_file, 'w') as ouput_file:
-        json.dump(clustering_metadata, ouput_file, indent=4)
+    if os.path.exists(clustering_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_clustering' in metadata_file]
+        clustering_metadata_file = os.path.join(output_folder, 'esmecata_metadata_clustering_{0}.json'.format(len(metadata_files)))
+        with open(clustering_metadata_file, 'w') as ouput_file:
+            json.dump(clustering_metadata, ouput_file, indent=4)
+    else:
+        with open(clustering_metadata_file, 'w') as ouput_file:
+            json.dump(clustering_metadata, ouput_file, indent=4)
 
-    logger.info('|EsMeCaTa|clustering| Clustering complete.')
+    logger.info('|EsMeCaTa|clustering| Clustering complete in {0}s.'.format(duration))

--- a/esmecata/clustering.py
+++ b/esmecata/clustering.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/eggnog.py
+++ b/esmecata/eggnog.py
@@ -326,23 +326,13 @@ def annotate_with_eggnog(input_folder, output_folder, eggnog_database_path, nb_c
 
         fasta_file_path = os.path.join(reference_protein_fasta_path, taxa_name+'.faa')
 
-        # Check if the annotation by eggnog-mapper has not been performed.
+        # Check if the annotation by eggnog-mapper has been performed.
         eggnog_mapper_annotation_file = os.path.join(eggnog_output_folder, taxa_name+'.emapper.annotations')
         if not os.path.exists(eggnog_mapper_annotation_file):
+            logger.info('|EsMeCaTa|annotation| Launch eggnog-mapper on %s.',  taxa_name)
             call_to_emapper(fasta_file_path, taxa_name, eggnog_output_folder, eggnog_temporary_dir, eggnog_database_path, nb_cpu)
-
-        reference_protein_pathname = os.path.join(reference_protein_path, taxa_name+'.tsv')
-        reference_proteins, set_proteins = extract_protein_cluster(reference_protein_pathname)
-
-        annotated_proteins = read_annotation(eggnog_mapper_annotation_file)
-        annotated_proteins = list(annotated_proteins)
-
-        gos = [go for protein_id, protein_annot in annotated_proteins for go in protein_annot['GOs'].split(',') if go not in ['', '-']]
-        unique_gos = set(gos)
-        ecs = [ec for protein_id, protein_annot in annotated_proteins for ec in protein_annot['EC'].split(',') if ec not in ['', '-']]
-        unique_ecs = set(ecs)
-        logger.info('|EsMeCaTa|annotation| %d Go Terms (with %d unique GO Terms) and %d EC numbers (with %d unique EC) associated with %s.', len(gos),
-                                                                                                len(unique_gos), len(ecs), len(unique_ecs), observation_name)
+        else:
+            logger.info('|EsMeCaTa|annotation| Results of eggnog-mapper already present for %s.',  taxa_name)
 
         # If temporary folder exists, remove it.
         if os.path.exists(eggnog_temporary_dir):
@@ -354,14 +344,24 @@ def annotate_with_eggnog(input_folder, output_folder, eggnog_database_path, nb_c
         reference_protein_pathname = os.path.join(reference_protein_path, proteomes_tax_name+'.tsv')
         reference_proteins, set_proteins = extract_protein_cluster(reference_protein_pathname)
 
-        # Create annotation reference file.
+        # Read eggnog output.
         eggnog_mapper_annotation_file = os.path.join(eggnog_output_folder, proteomes_tax_name+'.emapper.annotations')
         annotated_proteins = read_annotation(eggnog_mapper_annotation_file)
         annotated_proteins = list(annotated_proteins)
+
+        gos = [go for protein_id, protein_annot in annotated_proteins for go in protein_annot['GOs'].split(',') if go not in ['', '-']]
+        unique_gos = set(gos)
+        ecs = [ec for protein_id, protein_annot in annotated_proteins for ec in protein_annot['EC'].split(',') if ec not in ['', '-']]
+        unique_ecs = set(ecs)
+        logger.info('|EsMeCaTa|annotation| %d Go Terms (with %d unique GO Terms) and %d EC numbers (with %d unique EC) associated with %s.', len(gos),
+                                                                                                len(unique_gos), len(ecs), len(unique_ecs), observation_name)
+
+        # Create annotation reference file.
         annotation_reference_file = os.path.join(annotation_reference_folder, observation_name+'.tsv')
         if not os.path.exists(annotation_reference_file):
             write_annotation_reference(annotated_proteins, reference_proteins, annotation_reference_file)
 
+        # Create pathologic files.
         pathologic_organism_folder = os.path.join(pathologic_folder, observation_name)
         # Add _1 to pathologic file as genetic element cannot have the same name as the organism.
         pathologic_file = os.path.join(pathologic_organism_folder, observation_name+'_1.pf')

--- a/esmecata/eggnog.py
+++ b/esmecata/eggnog.py
@@ -397,8 +397,14 @@ def annotate_with_eggnog(input_folder, output_folder, eggnog_database_path, nb_c
     duration = endtime - starttime
     esmecata_metadata['esmecata_annotation_method'] = 'eggnog-mapper'
     esmecata_metadata['esmecata_annotation_duration'] = duration
-    uniprot_metadata_file = os.path.join(output_folder, 'esmecata_metadata_annotation.json')
-    with open(uniprot_metadata_file, 'w') as ouput_file:
-        json.dump(esmecata_metadata, ouput_file, indent=4)
+    eggnog_metadata_file = os.path.join(output_folder, 'esmecata_metadata_annotation.json')
+    if os.path.exists(eggnog_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_annotation' in metadata_file]
+        eggnog_metadata_file = os.path.join(output_folder, 'esmecata_metadata_annotation_{0}.json'.format(len(metadata_files)))
+        with open(eggnog_metadata_file, 'w') as ouput_file:
+            json.dump(esmecata_metadata, ouput_file, indent=4)
+    else:
+        with open(eggnog_metadata_file, 'w') as ouput_file:
+            json.dump(esmecata_metadata, ouput_file, indent=4)
 
-    logger.info('|EsMeCaTa|annotation-eggnog| Annotation complete.')
+    logger.info('|EsMeCaTa|annotation-eggnog| Annotation complete in {0}s.'.format(duration))

--- a/esmecata/eggnog.py
+++ b/esmecata/eggnog.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/proteomes.py
+++ b/esmecata/proteomes.py
@@ -1353,6 +1353,9 @@ def retrieve_proteomes(input_file, output_folder, busco_percentage_keep=80,
     options['tool_dependencies']['python_package']['pandas'] = pd.__version__
     options['tool_dependencies']['python_package']['requests'] = requests.__version__
     options['tool_dependencies']['python_package']['SPARQLWrapper'] = sparqlwrapper_version
+    if option_bioservices is True:
+        options['tool_dependencies']['python_package']['bioservices'] = bioservices.version
+
 
     if uniprot_sparql_endpoint:
         uniprot_releases = get_sparql_uniprot_release(uniprot_sparql_endpoint, options)

--- a/esmecata/proteomes.py
+++ b/esmecata/proteomes.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/proteomes.py
+++ b/esmecata/proteomes.py
@@ -1200,6 +1200,8 @@ def check_proteomes(input_file, output_folder, busco_percentage_keep=80,
         update_affiliations (str): option to update taxonomic affiliations.
         option_bioservices (bool): use bioservices instead of manual queries.
     """
+    check_starttime = time.time()
+
     logger.info('|EsMeCaTa|proteomes| Begin proteomes search.')
 
     retries = Retry(total=5, backoff_factor=0.25, status_forcelist=[429, 500, 502, 503, 504])
@@ -1302,6 +1304,10 @@ def check_proteomes(input_file, output_folder, busco_percentage_keep=80,
         proteome_to_download = set(proteome_to_download)
     # Create heatmap comparing input taxon and taxon used by esmecata to find proteomes.
     create_taxon_heatmap_from_complete_run(output_folder)
+
+    check_endtime = time.time()
+    check_duration = check_endtime - check_starttime
+    logger.info('|EsMeCaTa|proteomes| Check step complete in {0}s.'.format(check_duration))
 
     return proteome_to_download, session
 

--- a/esmecata/proteomes.py
+++ b/esmecata/proteomes.py
@@ -1367,7 +1367,13 @@ def retrieve_proteomes(input_file, output_folder, busco_percentage_keep=80,
     uniprot_releases['esmecata_proteomes_duration'] = duration
     json_log = os.path.join(output_folder, 'association_taxon_taxID.json')
     uniprot_metadata_file = os.path.join(output_folder, 'esmecata_metadata_proteomes.json')
-    with open(uniprot_metadata_file, 'w') as ouput_file:
-        json.dump(uniprot_releases, ouput_file, indent=4)
+    if os.path.exists(uniprot_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_proteomes' in metadata_file]
+        uniprot_metadata_file = os.path.join(output_folder, 'esmecata_metadata_proteomes_{0}.json'.format(len(metadata_files)))
+        with open(uniprot_metadata_file, 'w') as ouput_file:
+            json.dump(uniprot_releases, ouput_file, indent=4)
+    else:
+        with open(uniprot_metadata_file, 'w') as ouput_file:
+            json.dump(uniprot_releases, ouput_file, indent=4)
 
-    logger.info('|EsMeCaTa|proteomes| Proteome step complete.')
+    logger.info('|EsMeCaTa|proteomes| Proteome step complete in {0}s.'.format(duration))

--- a/esmecata/proteomes.py
+++ b/esmecata/proteomes.py
@@ -1354,6 +1354,7 @@ def retrieve_proteomes(input_file, output_folder, busco_percentage_keep=80,
     options['tool_dependencies']['python_package']['requests'] = requests.__version__
     options['tool_dependencies']['python_package']['SPARQLWrapper'] = sparqlwrapper_version
     if option_bioservices is True:
+        import bioservices
         options['tool_dependencies']['python_package']['bioservices'] = bioservices.version
 
 

--- a/esmecata/utils.py
+++ b/esmecata/utils.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/esmecata/workflow.py
+++ b/esmecata/workflow.py
@@ -110,6 +110,7 @@ def perform_workflow(input_file, output_folder, busco_percentage_keep=80, ignore
         option_bioservices (bool): use bioservices instead of manual queries.
     """
     starttime = time.time()
+    logger.info('|EsMeCaTa|workflow| Begin workflow.')
     workflow_metadata = {}
 
     if not os.path.exists(output_folder):
@@ -149,8 +150,17 @@ def perform_workflow(input_file, output_folder, busco_percentage_keep=80, ignore
     duration = endtime - starttime
     workflow_metadata['esmecata_workflow_duration'] = duration
     workflow_metadata_file = os.path.join(output_folder, 'esmecata_metadata_workflow.json')
-    with open(workflow_metadata_file, 'w') as ouput_file:
-        json.dump(workflow_metadata, ouput_file, indent=4)
+    if os.path.exists(workflow_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_workflow' in metadata_file]
+        workflow_metadata_file = os.path.join(output_folder, 'esmecata_metadata_workflow_{0}.json'.format(len(metadata_files)))
+        with open(workflow_metadata_file, 'w') as ouput_file:
+            json.dump(workflow_metadata, ouput_file, indent=4)
+    else:
+        with open(workflow_metadata_file, 'w') as ouput_file:
+            json.dump(workflow_metadata, ouput_file, indent=4)
+
+    logger.info('|EsMeCaTa|workflow| Workflow step complete in {0}s.'.format(duration))
+
 
 
 def perform_workflow_eggnog(input_file, output_folder, eggnog_database_path, busco_percentage_keep=80,

--- a/esmecata/workflow.py
+++ b/esmecata/workflow.py
@@ -40,11 +40,9 @@ def compute_stat_workflow(proteomes_output_folder, clustering_output_folder, ann
     """
     workflow_numbers = {}
 
-    proteome_tax_id_file = os.path.join(proteomes_output_folder, 'proteome_tax_id.tsv')
-    proteome_numbers = compute_stat_proteomes(proteome_tax_id_file)
+    proteome_numbers = compute_stat_proteomes(proteomes_output_folder)
 
-    clustering_folder = os.path.join(clustering_output_folder, 'reference_proteins')
-    clustering_numbers = compute_stat_clustering(clustering_folder)
+    clustering_numbers = compute_stat_clustering(clustering_output_folder)
 
     annotation_reference_folder = os.path.join(annotation_output_folder, 'annotation_reference')
     annotation_numbers = compute_stat_annotation(annotation_reference_folder)
@@ -52,7 +50,7 @@ def compute_stat_workflow(proteomes_output_folder, clustering_output_folder, ann
     all_observation_names = {*proteome_numbers.keys(), *clustering_numbers.keys(), *annotation_numbers.keys()}
     for observation_name in all_observation_names:
         if observation_name in proteome_numbers:
-            nb_proteomes = proteome_numbers[observation_name]
+            nb_proteomes, tax_name, lowest_tax_rank, esmecata_name, esmecata_rank, reference_status = proteome_numbers[observation_name]
         else:
             nb_proteomes = 'NA'
         if observation_name in clustering_numbers:
@@ -64,18 +62,18 @@ def compute_stat_workflow(proteomes_output_folder, clustering_output_folder, ann
             nb_ecs = annotation_numbers[observation_name][1]
         else:
             nb_proteomes = 'NA'
-        workflow_numbers[observation_name] = [nb_proteomes, nb_shared_proteins, nb_gos, nb_ecs]
+        workflow_numbers[observation_name] = [nb_proteomes, tax_name, lowest_tax_rank, esmecata_name, esmecata_rank, reference_status, nb_shared_proteins, nb_gos, nb_ecs]
 
     if stat_file:
         with open(stat_file, 'w') as stat_file_open:
             csvwriter = csv.writer(stat_file_open, delimiter='\t')
-            csvwriter.writerow(['observation_name', 'Number_proteomes', 'Number_shared_proteins', 'Number_go_terms', 'Number_ecs'])
+            csvwriter.writerow(['observation_name', 'Input_taxon_name', 'Input_rank', 'EsMeCaTa_chosen_name', 'EsMeCaTa_chosen_rank','Number_proteomes', 'Only_reference_proteome', 'Proteins_clusters_0_5' , 'Number_go_terms', 'Number_ecs'])
             for observation_name in workflow_numbers:
-                nb_proteomes = workflow_numbers[observation_name][0]
-                nb_shared_proteins = workflow_numbers[observation_name][1]
-                nb_gos = workflow_numbers[observation_name][2]
-                nb_ecs = workflow_numbers[observation_name][3]
-                csvwriter.writerow([observation_name, nb_proteomes, nb_shared_proteins, nb_gos, nb_ecs])
+                nb_proteomes, tax_name, lowest_tax_rank, esmecata_name, esmecata_rank, reference_status = workflow_numbers[observation_name][:6]
+                nb_shared_proteins = workflow_numbers[observation_name][6]
+                nb_gos = workflow_numbers[observation_name][7]
+                nb_ecs = workflow_numbers[observation_name][8]
+                csvwriter.writerow([observation_name, tax_name, lowest_tax_rank, esmecata_name, esmecata_rank, nb_proteomes, reference_status, nb_shared_proteins, nb_gos, nb_ecs])
 
     return workflow_numbers
 

--- a/esmecata/workflow.py
+++ b/esmecata/workflow.py
@@ -182,6 +182,7 @@ def perform_workflow_eggnog(input_file, output_folder, eggnog_database_path, bus
         eggnog_tmp_dir (str): pathname to eggnog-mapper temporary folder.
     """
     starttime = time.time()
+    logger.info('|EsMeCaTa|workflow| Begin workflow.')
     workflow_metadata = {}
 
     if not os.path.exists(output_folder):
@@ -220,5 +221,13 @@ def perform_workflow_eggnog(input_file, output_folder, eggnog_database_path, bus
     duration = endtime - starttime
     workflow_metadata['esmecata_workflow_duration'] = duration
     workflow_metadata_file = os.path.join(output_folder, 'esmecata_metadata_workflow.json')
-    with open(workflow_metadata_file, 'w') as ouput_file:
-        json.dump(workflow_metadata, ouput_file, indent=4)
+    if os.path.exists(workflow_metadata_file):
+        metadata_files = [metadata_file for metadata_file in os.listdir(output_folder) if 'esmecata_metadata_workflow' in metadata_file]
+        workflow_metadata_file = os.path.join(output_folder, 'esmecata_metadata_workflow_{0}.json'.format(len(metadata_files)))
+        with open(workflow_metadata_file, 'w') as ouput_file:
+            json.dump(workflow_metadata, ouput_file, indent=4)
+    else:
+        with open(workflow_metadata_file, 'w') as ouput_file:
+            json.dump(workflow_metadata, ouput_file, indent=4)
+
+    logger.info('|EsMeCaTa|workflow| Workflow step complete in {0}s.'.format(duration))

--- a/esmecata/workflow.py
+++ b/esmecata/workflow.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2021-2023 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Copyright (C) 2021-2024 Arnaud Belcour - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Univ. Grenoble Alpes, Inria, Microcosme
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -1,7 +1,7 @@
 import csv
 import os
 import shutil
-
+import subprocess
 from esmecata.clustering import make_clustering, filter_protein_cluster, compute_proteome_representativeness_ratio
 
 RESULTS = {
@@ -48,6 +48,25 @@ def test_make_clustering():
     output_folder = 'clustering_output'
     make_clustering('clustering_input', output_folder, nb_cpu=1, clust_threshold=0.5, mmseqs_options=None, linclust=None, remove_tmp=None)
 
+    expected_results = {}
+    output_stat_file = os.path.join(output_folder, 'stat_number_clustering.tsv')
+    with open(output_stat_file, 'r') as stat_file_read:
+        csvreader = csv.reader(stat_file_read, delimiter='\t')
+        next(csvreader)
+        for line in csvreader:
+            expected_results[line[0]] = {}
+            expected_results[line[0]]['Number_shared_proteins'] = int(line[1])
+
+    for observation_name in expected_results:
+        for data in expected_results[observation_name]:
+            assert expected_results[observation_name][data] == RESULTS[observation_name][data]
+
+    shutil.rmtree(output_folder)
+
+
+def test_clustering_cli():
+    output_folder = 'clustering_output'
+    subprocess.call(['esmecata', 'clustering', '-i', 'clustering_input', '-o', output_folder, '-c', '1', '-t', '0.5'])
     expected_results = {}
     output_stat_file = os.path.join(output_folder, 'stat_number_clustering.tsv')
     with open(output_stat_file, 'r') as stat_file_read:

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -5,7 +5,7 @@ import shutil
 from esmecata.clustering import make_clustering, filter_protein_cluster, compute_proteome_representativeness_ratio
 
 RESULTS = {
-    'Cluster_1': {'Number_shared_proteins': 460}
+    'Cluster_1': {'Number_shared_proteins': 604}
 }
 
 def test_filter_protein_cluster():
@@ -46,7 +46,7 @@ def test_filter_protein_cluster():
 
 def test_make_clustering():
     output_folder = 'clustering_output'
-    make_clustering('clustering_input', output_folder, nb_cpu=1, clust_threshold=0.95, mmseqs_options=None, linclust=None, remove_tmp=None)
+    make_clustering('clustering_input', output_folder, nb_cpu=1, clust_threshold=0.5, mmseqs_options=None, linclust=None, remove_tmp=None)
 
     expected_results = {}
     output_stat_file = os.path.join(output_folder, 'stat_number_clustering.tsv')

--- a/test/test_proteomes.py
+++ b/test/test_proteomes.py
@@ -1,5 +1,7 @@
+import csv
 import os
 import shutil
+import subprocess
 import time
 
 from collections import OrderedDict, Counter
@@ -379,6 +381,18 @@ def test_sparql_find_proteomes_tax_ids():
         assert expected_proteomes_ids[taxon][0] == proteomes_ids[taxon][0]
         assert set(expected_proteomes_ids[taxon][1]) == set(proteomes_ids[taxon][1])
 
+
+def test_check_cli():
+    output_folder = 'proteomes_output'
+    subprocess.call(['esmecata', 'check', '-i', 'buchnera_workflow.tsv', '-o', output_folder])
+    expected_results = []
+    output_stat_file = os.path.join(output_folder, 'proteome_tax_id.tsv')
+    with open(output_stat_file, 'r') as stat_file_read:
+        csvreader = csv.reader(stat_file_read, delimiter='\t')
+        next(csvreader)
+        for line in csvreader:
+            expected_results.append(line[3])
+    assert expected_results == ['species']
 
 if __name__ == "__main__":
     #test_find_proteomes_tax_ids()

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -4,12 +4,12 @@ import subprocess
 import shutil
 
 RESULTS = {
-    'Cluster_1': {'proteomes': 2, 'protein_clusters': 460, 'GOs': 621, 'ECs': 245}
+    'Cluster_1': {'proteomes': 2, 'protein_clusters': 604, 'GOs': 754, 'ECs': 312}
 }
 
 
 def test_workflow():
-    subprocess.call(['esmecata', 'workflow', '-i', 'buchnera_workflow.tsv', '-o', 'test_output', '-p', '1', '--minimal-nb-proteomes', '1', '-t', '0.95'])
+    subprocess.call(['esmecata', 'workflow', '-i', 'buchnera_workflow.tsv', '-o', 'test_output', '-p', '1', '--minimal-nb-proteomes', '2'])
 
     output_stat_file = os.path.join('test_output', 'stat_number_workflow.tsv')
 
@@ -19,10 +19,10 @@ def test_workflow():
         next(csvreader)
         for line in csvreader:
             expected_results[line[0]] = {}
-            expected_results[line[0]]['proteomes'] = int(line[1])
-            expected_results[line[0]]['protein_clusters'] = int(line[2])
-            expected_results[line[0]]['GOs'] = int(line[3])
-            expected_results[line[0]]['ECs'] = int(line[4])
+            expected_results[line[0]]['proteomes'] = int(line[5])
+            expected_results[line[0]]['protein_clusters'] = int(line[7])
+            expected_results[line[0]]['GOs'] = int(line[8])
+            expected_results[line[0]]['ECs'] = int(line[9])
 
     for observation_name in expected_results:
         for data in expected_results[observation_name]:

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -9,7 +9,7 @@ RESULTS = {
 
 
 def test_workflow():
-    subprocess.call(['esmecata', 'workflow', '-i', 'buchnera_workflow.tsv', '-o', 'test_output', '-p', '1', '--minimal-nb-proteomes', '2'])
+    subprocess.call(['esmecata', 'workflow_uniprot', '-i', 'buchnera_workflow.tsv', '-o', 'test_output', '-p', '1', '--minimal-nb-proteomes', '2'])
 
     output_stat_file = os.path.join('test_output', 'stat_number_workflow.tsv')
 

--- a/tutorials/esmecata_method.ipynb
+++ b/tutorials/esmecata_method.ipynb
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -518,7 +518,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Retrieve annotation from UniProt\n",
+    "### Retrieve annotation using eggnog-mapper\n",
+    "\n",
+    "Using the protein clusters kept during the previous step, EsMeCaTa will use eggnog-mapper to annotate the consensus protein sequences associated with the protein clusters. \n",
+    "\n",
+    "It will return:\n",
+    "\n",
+    "- protein name\n",
+    "- list of GO Terms\n",
+    "- list of Enzyme Commissions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Retrieve annotation from UniProt (less accurate)\n",
     "\n",
     "Using the protein cluster kept during the previous step, EsMeCaTa will query UniProt to get the annotations of the proteins inside each cluster.\n",
     "\n",


### PR DESCRIPTION
Rework how intermediary files (for clustering and annotation) are stored. Instead of assigning one file per observation name, this new version assigns one file per taxon used by EsMeCaTa. This removes a lot of redundant work that slowed EsMeCaTa and could lead to issue.

Also change the default annotation method used by the sub-command `workflow`. Now, eggnog-mapper is used by default.

## Add

* Add sub-commands `annotation_uniprot` and `workflow_uniprot` to use the old method of protein annotation.
* Add `check` subcommand that performs the first step of EsMeCaTa without downloading the proteomes. This is helpful when you want to have a glimpse on the available knowledge for your dataset.

## Fix

* Missing import in proteomes.

## Modify

* Modify intermediary files to associate them with taxon nma used by EsMeCaTa instead of the observation name. This decreases the redundancy in files create by EsMeCaTa, decreasing the space took for `clustering` and `annotation`.
* Instead of erasing previous metadata files, create a new one if the run has failed and was launched again.
* Update license year.

## Remove

* Remove sub-commands `annotation_eggnog` and `workflow_eggnog` which are now the default sub-commands `annotation` and `workflow`.