### PR TITLE
Move to 0.6.1.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,5 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -10,28 +10,61 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
-  deploy:
-
+  release-build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine build
-        pip install -r requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        twine upload dist/*
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build wheel
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      url: https://pypi.org/p/esmecata
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# EsMeCaTa v0.6.1 (2025-02-25)
+# EsMeCaTa v0.6.1 (2025-03-03)
 
 ## Fix
 
@@ -9,6 +9,7 @@
 ## Modify
 
 * Use taxon ID to search for taxon presence in precomputed database.
+* Use Trusted publisher to publish on PyPI.
 
 # EsMeCaTa v0.6.0 (2025-01-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-# EsMeCaTa v0.6.1 (2025-02-21)
+# EsMeCaTa v0.6.1 (2025-02-25)
 
 ## Fix
 
 * Issue with tax synonyms on the same tax rank when filtering rank in `proteomes`.
+
+## Modify
+
+* Use taxon ID to search for taxon presence in precomputed database.
 
 # EsMeCaTa v0.6.0 (2025-01-27)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ EsMeCaTa is a method to estimate consensus proteomes and metabolic capabilities 
 
 ## Requirements
 
+Requirements for EsMeCaTa vary depending on the command used.
+
 EsMeCaTa is developed in Python, it is tested with Python 3.11. It needs the following python packages:
  
 - [biopython](https://pypi.org/project/biopython/): To create fasta files and used by the option `--annotation-files` to index UniProt flat files.
@@ -110,6 +112,7 @@ To use eggNOG-mapper, you have to setup it and install [its database](https://gi
 - [plotly](https://github.com/plotly/plotly.py).
 - [kaleido](https://github.com/plotly/Kaleido)
 - [ontosunburst](https://github.com/AuReMe/Ontology_sunburst).
+- [bokeh](https://github.com/bokeh/bokeh)
 
 **Warning**: due to the fact that datapane is no longer maintained, it requires a version of pandas lower than `2.0.0`. `esmecata_report` has been used with pandas `1.5.3`.
 The replacement of datapane by [panel](https://github.com/holoviz/panel) is under development to solve this issue.

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: test_env
 channels:
-  - defaults
   - bioconda
   - conda-forge
 dependencies:

--- a/esmecata/__init__.py
+++ b/esmecata/__init__.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/esmecata/core/eggnog.py
+++ b/esmecata/core/eggnog.py
@@ -32,6 +32,9 @@ from esmecata.core.annotation import extract_protein_cluster, create_dataset_ann
 from esmecata.core.clustering import get_proteomes_tax_id_name
 
 from ete3 import NCBITaxa
+from ete3 import __version__ as ete3_version
+
+from Bio import __version__ as biopython_version
 from Bio import SeqIO
 
 logger = logging.getLogger(__name__)
@@ -438,6 +441,8 @@ def annotate_with_eggnog(input_folder, output_folder, eggnog_database_path, nb_c
     options['tool_dependencies']['python_package']['Python_version'] = sys.version
     options['tool_dependencies']['python_package']['esmecata'] = esmecata_version
     options['tool_dependencies']['python_package']['pandas'] = pd.__version__
+    options['tool_dependencies']['python_package']['ete3'] = ete3_version
+    options['tool_dependencies']['python_package']['biopython'] = biopython_version
     options['tool_dependencies']['eggnog_mapper'] = get_eggnog_version()
 
     esmecata_metadata = {}


### PR DESCRIPTION
## Fix

* Issue with tax synonyms on the same tax rank when filtering rank in `proteomes`.

## Modify

* Use taxon ID to search for taxon presence in precomputed database.
* Use Trusted publisher to publish on PyPI.