### PR TITLE
EsMeCaTa 0.6.2: replace datapane and ete3 by arakawa and ete4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,6 +50,7 @@ jobs:
         brew install mmseqs2
         mmseqs -h
         pip install -e . --config-settings editable_mode=compat
+        pip install git+https://github.com/etetoolkit/ete.git@a96d66643b7dd53c1d60968b610c5cd6c9497a9c
         pip install datapane plotly ontosunburst kaleido numpy==1.26.4
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,8 +49,8 @@ jobs:
         brew update
         brew install mmseqs2
         mmseqs -h
-        pip install -e . --config-settings editable_mode=compat
-        pip install datapane plotly ontosunburst kaleido numpy==1.26.4
+        pip install -e .
+        pip install arakawa plotly ontosunburst kaleido numpy
     - name: Test with pytest
       run: |
         pip install pytest pytest-mock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-# EsMeCaTa v0.6.2 (2025-03-06)
+# EsMeCaTa v0.6.2 (2025-03-07)
 
 ## Modify
 
 * Replace `datapane` by `arakawa` for HTML report creation in `esmecata_report`. Make HTMLs standalone (they are a lot bigger but bo not require internet to display).
+* Replace `ete3` by `ete4` as ete3 is no longer maintained.
 
 # EsMeCaTa v0.6.1 (2025-03-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# EsMeCaTa v0.6.2 (2025-03-06)
+
+## Modify
+
+* Replace `datapane` by `arakawa` for HTML report creation in `esmecata_report`. Make HTMLs standalone (they are a lot bigger but bo not require internet to display).
+
 # EsMeCaTa v0.6.1 (2025-03-03)
 
 ## Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## Modify
 
-* Replace `datapane` by `arakawa` for HTML report creation in `esmecata_report`. Make HTMLs standalone (they are a lot bigger but bo not require internet to display).
-* Replace `ete3` by `ete4` as ete3 is no longer maintained.
+* Replace `datapane` by `arakawa` for HTML report creation in `esmecata_report` (issue #20). Make HTMLs standalone (they are a lot bigger but bo not require internet to display).
+* Replace `ete3` by `ete4` as ete3 is no longer maintained (issue #18).
 
 # EsMeCaTa v0.6.1 (2025-03-03)
 

--- a/README.md
+++ b/README.md
@@ -108,23 +108,24 @@ To use eggNOG-mapper, you have to setup it and install [its database](https://gi
 
 `esmecata_report` requires:
 
-- [datapane](https://github.com/datapane/datapane).
-- [plotly](https://github.com/plotly/plotly.py).
-- [kaleido](https://github.com/plotly/Kaleido)
-- [ontosunburst](https://github.com/AuReMe/Ontology_sunburst).
-- [bokeh](https://github.com/bokeh/bokeh)
+- [arakawa](https://github.com/ninoseki/arakawa): fork of [datapane](https://github.com/datapane/datapane) to create the HTML report.
+- [plotly](https://github.com/plotly/plotly.py): to create most of the figures.
+- [ontosunburst](https://github.com/AuReMe/Ontology_sunburst): to create sunburst figures of Enzyme Commission numbers.
+- [kaleido](https://github.com/plotly/Kaleido): required to create the figure.
+- [bokeh](https://github.com/bokeh/bokeh): required to create the figure.
 
-**Warning**: due to the fact that datapane is no longer maintained, it requires a version of pandas lower than `2.0.0`. `esmecata_report` has been used with pandas `1.5.3`.
-The replacement of datapane by [panel](https://github.com/holoviz/panel) is under development to solve this issue.
+This can be installed with pip:
+
+```pip install arakawa bokeh plotly kaleido ontosunburst```
 
 `esmecata_gseapy` requires:
 - [pronto](https://github.com/althonos/pronto): to get Gene Ontology names.
 - [gseapy](https://github.com/zqfang/GSEApy): to perform enrichment analysis.
 - [orsum](https://github.com/ozanozisik/orsum): to visualize the results of enrichment analysis.
 
-All dependencies can be installed with following command:
+These dependencies can be installed with conda:
 
-```conda install mmseqs2 pandas=1.5.3 sparqlwrapper requests biopython ete3 eggnog-mapper orsum gseapy plotly datapane python-kaleido -c conda-forge -c bioconda```
+```conda install pronto orsum gseapy plotly -c conda-forge -c bioconda```
 
 ## Input
 
@@ -975,7 +976,7 @@ subcommands:
     create_report_annotation
                         Create report from esmecata output folder of annotation subcommand.
 
-Requires: datapane, plotly, kaleido, ontosunburst.
+Requires: arakawa, bokeh, plotly, kaleido, ontosunburst.
 ```
 
 It can be used with this command:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you use the option `--bioservices`, EsMeCaTa will also require this package:
 **Warning**: due to change in sqlite, ete3 is no more working. To continue working, EsMeCaTa now uses ete4.
 But ete4 is not yet available on pip or conda, so you have to install it from its github repository with the command:
 
-```pip install git+https://github.com/etetoolkit/ete.git```
+```pip install git+https://github.com/etetoolkit/ete.git@a96d66643b7dd53c1d60968b610c5cd6c9497a9c```
 
 Once ete4 has been released, I will update the requirements.
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ If you use the option `--bioservices`, EsMeCaTa will also require this package:
 
 ## Installation
 
-**Warning**: due to change in sqlite, ete3 is no more working. To continue working, EsMeCaTa now uses ete4.
+**Warning**: due to change in sqlite, there is issue when using ete3 from PyPI. To continue working, EsMeCaTa now relies on ete4.
 For all use of EsMeCaTa, you have to install ete4.
-But ete4 is not yet available on pip or conda, so you have to install it from its github repository with the command:
+But ete4 is not yet available on PyPI or conda, so you have to install it from its github repository with the command:
 
 ```pip install git+https://github.com/etetoolkit/ete.git@a96d66643b7dd53c1d60968b610c5cd6c9497a9c```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you use the option `--bioservices`, EsMeCaTa will also require this package:
 ## Installation
 
 **Warning**: due to change in sqlite, ete3 is no more working. To continue working, EsMeCaTa now uses ete4.
+For all use of EsMeCaTa, you have to install ete4.
 But ete4 is not yet available on pip or conda, so you have to install it from its github repository with the command:
 
 ```pip install git+https://github.com/etetoolkit/ete.git@a96d66643b7dd53c1d60968b610c5cd6c9497a9c```

--- a/README.md
+++ b/README.md
@@ -112,11 +112,10 @@ To use eggNOG-mapper, you have to setup it and install [its database](https://gi
 - [plotly](https://github.com/plotly/plotly.py): to create most of the figures.
 - [ontosunburst](https://github.com/AuReMe/Ontology_sunburst): to create sunburst figures of Enzyme Commission numbers.
 - [kaleido](https://github.com/plotly/Kaleido): required to create the figure.
-- [bokeh](https://github.com/bokeh/bokeh): required to create the figure.
 
 This can be installed with pip:
 
-```pip install arakawa bokeh plotly kaleido ontosunburst```
+```pip install arakawa plotly kaleido ontosunburst```
 
 `esmecata_gseapy` requires:
 - [pronto](https://github.com/althonos/pronto): to get Gene Ontology names.
@@ -976,7 +975,7 @@ subcommands:
     create_report_annotation
                         Create report from esmecata output folder of annotation subcommand.
 
-Requires: arakawa, bokeh, plotly, kaleido, ontosunburst.
+Requires: arakawa, plotly, kaleido, ontosunburst.
 ```
 
 It can be used with this command:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ EsMeCaTa is a method to estimate consensus proteomes and metabolic capabilities 
   - [EsMeCaTa gseapy](#esmecata-gseapy)
   - [EsMeCaTa create\_db](#esmecata-create_db)
   - [Troubleshooting](#troubleshooting)
-    - [Issue with incompatible versions of ete3 and UniProt NCBI Taxonomy databases](#issue-with-incompatible-versions-of-ete3-and-uniprot-ncbi-taxonomy-databases)
+    - [Issue with incompatible versions of ete4 and UniProt NCBI Taxonomy databases](#issue-with-incompatible-versions-of-ete4-and-uniprot-ncbi-taxonomy-databases)
   - [Citation](#citation)
   - [License](#license)
 
@@ -51,7 +51,7 @@ EsMeCaTa is developed in Python, it is tested with Python 3.11. It needs the fol
 - [biopython](https://pypi.org/project/biopython/): To create fasta files and used by the option `--annotation-files` to index UniProt flat files.
 - [pandas](https://pypi.org/project/pandas/): To read the input files.
 - [requests](https://pypi.org/project/requests/): For the REST queries on Uniprot.
-- [ete3](https://pypi.org/project/ete3/): To analyse the taxonomic affiliation and extract taxon_id, also used to deal with taxon associated with more than 100 proteomes.
+- [ete4](https://pypi.org/project/ete4/): To analyse the taxonomic affiliation and extract taxon_id, also used to deal with taxon associated with more than 100 proteomes.
 - [SPARQLwrapper](https://pypi.org/project/SPARQLWrapper/): Optionally, you can use SPARQL queries instead of REST queries. This can be done either with the [Uniprot SPARQL Endpoint](https://sparql.uniprot.org/) (with the option `--sparql uniprot`) or with a Uniprot SPARQL Endpoint that you created locally (it is supposed to work but not tested, only SPARQL queries on the Uniprot SPARQL endpoint have been tested). **Warning**: using SPARQL queries will lead to minor differences in functional annotations and metabolic reactions due to how the results are retrieved with REST query or SPARQL query.
 
 Also esmecata requires MMseqs2 for protein clustering with `esmecata workflow` or `esmecata clustering`:
@@ -69,6 +69,13 @@ If you use the option `--bioservices`, EsMeCaTa will also require this package:
 - [bioservices](https://github.com/cokelaer/bioservices): To query Uniprot instead of using the query functions of EsMeCaTa (potentially more robust overtime).
 
 ## Installation
+
+**Warning**: due to change in sqlite, ete3 is no more working. To continue working, EsMeCaTa now uses ete4.
+But ete4 is not yet available on pip or conda, so you have to install it from its github repository with the command:
+
+```pip install git+https://github.com/etetoolkit/ete.git```
+
+Once ete4 has been released, I will update the requirements.
 
 ### With the precomputed database
 
@@ -88,7 +95,7 @@ As this file is quite big and if you want just to test `esmecata precomputed`, y
 
 For the whole workflow, the easiest way to install the dependencies of EsMeCaTa is by using conda (or mamba):
 
-```conda install mmseqs2 pandas sparqlwrapper requests biopython ete3 eggnog-mapper -c conda-forge -c bioconda```
+```conda install mmseqs2 pandas sparqlwrapper requests biopython eggnog-mapper -c conda-forge -c bioconda```
 
 EsMeCaTa is available on [PyPI](https://pypi.org/project/esmecata/) and can be installed with pip:
 
@@ -124,7 +131,7 @@ The replacement of datapane by [panel](https://github.com/holoviz/panel) is unde
 
 All dependencies can be installed with following command:
 
-```conda install mmseqs2 pandas=1.5.3 sparqlwrapper requests biopython ete3 eggnog-mapper orsum gseapy plotly datapane python-kaleido -c conda-forge -c bioconda```
+```conda install mmseqs2 pandas=1.5.3 sparqlwrapper requests biopython eggnog-mapper orsum gseapy plotly datapane python-kaleido -c conda-forge -c bioconda```
 
 ## Input
 
@@ -216,7 +223,7 @@ options:
                         This option limits the rank used when searching for proteomes. All the ranks superior to the given rank will be ignored. For example, if 'family' is given, only taxon ranks inferior or equal to family will be kept. Look at the readme for more
                         information (and a list of rank names).
   --update-affiliations
-                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
+                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
   -t THRESHOLD_CLUSTERING, --threshold THRESHOLD_CLUSTERING
                         Proportion [0 to 1] of proteomes required to occur in a proteins cluster for that cluster to be kept in core proteome assembly. Default is 0.5.
 ```
@@ -264,7 +271,7 @@ options:
   -b BUSCO, --busco BUSCO
                         BUSCO percentage between 0 and 1. This will remove all the proteomes without BUSCO score and the score before the selected ratio of completion.
   --ignore-taxadb-update
-                        If you have a not up-to-date version of the NCBI taxonomy database with ete3, use this option to bypass the warning message and use the old version.
+                        If you have a not up-to-date version of the NCBI taxonomy database with ete4, use this option to bypass the warning message and use the old version.
   --all-proteomes       Download all proteomes associated with a taxon even if they are no reference proteomes.
   -s SPARQL, --sparql SPARQL
                         Use sparql endpoint instead of REST queries on Uniprot.
@@ -276,15 +283,15 @@ options:
   --minimal-nb-proteomes MINIMAL_NUMBER_PROTEOMES
                         Choose the minimal number of proteomes to be selected by EsMeCaTa. If a taxon has less proteomes, it will be ignored and a higher taxonomic rank will be used. Default is 5.
   --update-affiliations
-                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
+                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
   --bioservices         Use bioservices instead of esmecata functions for protein annotation.
 ```
 
-For each taxon in each taxonomic affiliations EsMeCaTa will use ete3 to find the corresponding taxon ID. Then it will search for proteomes associated with these taxon ID in the Uniprot Proteomes database.
+For each taxon in each taxonomic affiliations EsMeCaTa will use ete4 to find the corresponding taxon ID. Then it will search for proteomes associated with these taxon ID in the Uniprot Proteomes database.
 
 If there is more than 100 proteomes, esmecata applies a subsampling procedure:
 
-* (1) use the taxon ID associated with each proteomes to create a taxonomic tree with ete3.
+* (1) use the taxon ID associated with each proteomes to create a taxonomic tree with ete4.
 
 * (2) from the root of the tree (the input taxon), esmecata will find the direct descendants (sub-taxa).
 
@@ -305,9 +312,9 @@ It is possible to avoid using REST queries for esmecata and instead use SPARQL q
 
 It is possible to filter proteomes according to to their BUSCO score (from UniProt documentation: `The Benchmarking Universal Single-Copy Ortholog (BUSCO) assessment tool is used, for eukaryotic and bacterial proteomes, to provide quantitative measures of UniProt proteome data completeness in terms of expected gene content.`). It is a percentage between 0 and 1 showing the quality of the proteomes that esmecata will download. By default esmecata uses a BUSCO score of 0.80, it will only download proteomes with a BUSCO score of at least 80%.
 
-* `--ignore-taxadb-update`: ignore need to udpate ete3 taxaDB
+* `--ignore-taxadb-update`: ignore need to udpate ete4 taxaDB
 
-If you have an old version of the ete3 NCBI taxonomy database, you can use this option to use esmecata with it.
+If you have an old version of the ete4 NCBI taxonomy database, you can use this option to use esmecata with it.
 
 * `--all-proteomes`: download all proteomes (reference and non-reference)
 
@@ -401,7 +408,7 @@ optional arguments:
   -b BUSCO, --busco BUSCO
                         BUSCO percentage between 0 and 1. This will remove all the proteomes without BUSCO score and the score before the selected ratio of completion.
   --ignore-taxadb-update
-                        If you have a not up-to-date version of the NCBI taxonomy database with ete3, use this option to bypass the warning message and use the old version.
+                        If you have a not up-to-date version of the NCBI taxonomy database with ete4, use this option to bypass the warning message and use the old version.
   --all-proteomes       Download all proteomes associated with a taxon even if they are no reference proteomes.
   -s SPARQL, --sparql SPARQL
                         Use sparql endpoint instead of REST queries on Uniprot.
@@ -413,7 +420,7 @@ optional arguments:
   --minimal-nb-proteomes MINIMAL_NUMBER_PROTEOMES
                         Choose the minimal number of proteomes to be selected by EsMeCaTa. If a taxon has less proteomes, it will be ignored and a higher taxonomic rank will be used. Default is 1.
   --update-affiliations
-                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. This option tries to udpate the taxonomic affiliations using the lowest taxon
+                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. This option tries to udpate the taxonomic affiliations using the lowest taxon
                         name.
   --bioservices         Use bioservices instead of esmecata functions for protein annotation.
 ````
@@ -582,7 +589,7 @@ options:
                         BUSCO percentage between 0 and 1. This will remove all the proteomes without BUSCO score and the score before the selected ratio of completion.
   -c CPU, --cpu CPU     CPU number for multiprocessing.
   --ignore-taxadb-update
-                        If you have a not up-to-date version of the NCBI taxonomy database with ete3, use this option to bypass the warning message and use the old version.
+                        If you have a not up-to-date version of the NCBI taxonomy database with ete4, use this option to bypass the warning message and use the old version.
   --all-proteomes       Download all proteomes associated with a taxon even if they are no reference proteomes.
   -s SPARQL, --sparql SPARQL
                         Use sparql endpoint instead of REST queries on Uniprot.
@@ -600,7 +607,7 @@ options:
   --minimal-nb-proteomes MINIMAL_NUMBER_PROTEOMES
                         Choose the minimal number of proteomes to be selected by EsMeCaTa. If a taxon has less proteomes, it will be ignored and a higher taxonomic rank will be used. Default is 5.
   --update-affiliations
-                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
+                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. This option tries to udpate the taxonomic affiliations using the lowest taxon name.
   --bioservices         Use bioservices instead of esmecata functions for protein annotation.
   --eggnog-tmp EGGNOG_TMP_DIR
                         Path to eggnog tmp dir.
@@ -624,7 +631,7 @@ options:
                         BUSCO percentage between 0 and 1. This will remove all the proteomes without BUSCO score and the score before the selected ratio of completion.
   -c CPU, --cpu CPU     CPU number for multiprocessing.
   --ignore-taxadb-update
-                        If you have a not up-to-date version of the NCBI taxonomy database with ete3, use this option to bypass the warning message and use the old version.
+                        If you have a not up-to-date version of the NCBI taxonomy database with ete4, use this option to bypass the warning message and use the old version.
   --all-proteomes       Download all proteomes associated with a taxon even if they are no reference proteomes.
   -s SPARQL, --sparql SPARQL
                         Use sparql endpoint instead of REST queries on Uniprot.
@@ -649,7 +656,7 @@ options:
   --annotation-files ANNOTATION_FILES
                         Use UniProt annotation files (uniprot_trembl.txt and uniprot_sprot.txt) to avoid querying UniProt REST API. Need both paths to these files separated by a ",".
   --update-affiliations
-                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. This option tries to update the taxonomic affiliations using the lowest taxon name.
+                        If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. This option tries to update the taxonomic affiliations using the lowest taxon name.
   --bioservices         Use bioservices instead of esmecata functions for protein annotation.
 ````
 
@@ -681,7 +688,7 @@ The `proteomes_description` contains list of proteomes find by esmecata on Unipr
 
 The `proteomes` contains all the proteomes that have been found to be associated with one taxon. It will be used for the clustering step.
 
-`association_taxon_taxID.json` contains for each `observation_name` the name of the taxon and the corresponding taxon_id found with `ete3`.
+`association_taxon_taxID.json` contains for each `observation_name` the name of the taxon and the corresponding taxon_id found with `ete4`.
 
 `empty_proteome.tsv` contains UniProt proteome ID that have been downloaded but are empty.
 
@@ -1077,12 +1084,12 @@ To merge several precomputed databases, you can use the following command:
 
 ## Troubleshooting
 
-### Issue with incompatible versions of ete3 and UniProt NCBI Taxonomy databases
+### Issue with incompatible versions of ete4 and UniProt NCBI Taxonomy databases
 
-A common issue encountered when using EsMeCaTa is that the NCBI Taxonomy database present in the ete3 package (and used to parse the input taxonomic affiliations) is different from the ones used by UniProt. This can lead to several issues at different levels of EsMeCaTa. A possible solution is to update the NCBI Taxonomy database of ete3 with the following command:
+A common issue encountered when using EsMeCaTa is that the NCBI Taxonomy database present in the ete4 package (and used to parse the input taxonomic affiliations) is different from the ones used by UniProt. This can lead to several issues at different levels of EsMeCaTa. A possible solution is to update the NCBI Taxonomy database of ete4 with the following command:
 
 ```
-python3 -c "from ete3 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database()"
+python3 -c "from ete4 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database()"
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To use eggNOG-mapper, you have to setup it and install [its database](https://gi
 
 This can be installed with pip:
 
-```pip install arakawa plotly kaleido ontosunburst```
+```pip install arakawa==0.0.15 plotly kaleido ontosunburst```
 
 `esmecata_gseapy` requires:
 - [pronto](https://github.com/althonos/pronto): to get Gene Ontology names.

--- a/article_data/README.md
+++ b/article_data/README.md
@@ -68,10 +68,10 @@ For a better change to reproduce the results, it is recommended to use the NCBI 
 | Pig Gut                   | 2023_05 | 12-2023       |
 | Methanogenic reactor      | 2024_01 | 01-2024       |
 
-You can update the NCBI Taxonomy database used by ete3 with the following command (here we use as example `taxdmp_2024-01.tar.gz` associated with the methanogenic reactor):
+You can update the NCBI Taxonomy database used by ete4 with the following command (here we use as example `taxdmp_2024-01.tar.gz` associated with the methanogenic reactor):
 
 ```
-python3 -c "from ete3 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database('taxdmp_2024-01.tar.gz')"
+python3 -c "from ete4 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database('taxdmp_2024-01.tar.gz')"
 ```
 
 This will create output folder containing the predictions for the associated organisms of the community.

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - sparqlwrapper
   - requests
   - biopython
-  - ete3
   - eggnog-mapper
   - orsum
   - gseapy

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - mmseqs2
-  - pandas=1.5.3
+  - pandas
   - sparqlwrapper
   - requests
   - biopython
@@ -13,7 +13,6 @@ dependencies:
   - orsum
   - gseapy
   - plotly
-  - datapane
   - python-kaleido
   - pytest
   - pytest-mock

--- a/esmecata/__init__.py
+++ b/esmecata/__init__.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'

--- a/esmecata/__main__.py
+++ b/esmecata/__main__.py
@@ -113,7 +113,7 @@ def main():
     parent_parser_taxadb.add_argument(
         '--ignore-taxadb-update',
         dest='ignore_taxadb_update',
-        help='If you have a not up-to-date version of the NCBI taxonomy database with ete3, use this option to bypass the warning message and use the old version.',
+        help='If you have a not up-to-date version of the NCBI taxonomy database with ete4, use this option to bypass the warning message and use the old version.',
         required=False,
         action='store_true',
         default=None)
@@ -138,7 +138,7 @@ def main():
     parent_parser_update_affiliation.add_argument(
         '--update-affiliations',
         dest='update_affiliations',
-        help='''If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete3 database. \
+        help='''If the taxonomic affiliations were assigned from an outdated taxonomic database, this can lead to taxon not be found in ete4 database. \
             This option tries to update the taxonomic affiliations using the lowest taxon name.''',
         required=False,
         action='store_true',

--- a/esmecata/__main_report__.py
+++ b/esmecata/__main_report__.py
@@ -28,7 +28,7 @@ MESSAGE = '''
 Create report files from esmecata output folder.
 '''
 REQUIRES = '''
-Requires: arakawa, bokeh, plotly, kaleido, ontosunburst.
+Requires: arakawa, plotly, kaleido, ontosunburst.
 '''
 
 logger = logging.getLogger()

--- a/esmecata/__main_report__.py
+++ b/esmecata/__main_report__.py
@@ -28,7 +28,7 @@ MESSAGE = '''
 Create report files from esmecata output folder.
 '''
 REQUIRES = '''
-Requires: datapane, plotly, kaleido, ontosunburst.
+Requires: arakawa, bokeh, plotly, kaleido, ontosunburst.
 '''
 
 logger = logging.getLogger()

--- a/esmecata/core/eggnog.py
+++ b/esmecata/core/eggnog.py
@@ -31,8 +31,8 @@ from esmecata import __version__ as esmecata_version
 from esmecata.core.annotation import extract_protein_cluster, create_dataset_annotation_file
 from esmecata.core.clustering import get_proteomes_tax_id_name
 
-from ete3 import NCBITaxa
-from ete3 import __version__ as ete3_version
+from ete4 import NCBITaxa
+from ete4 import __version__ as ete4_version
 
 from Bio import __version__ as biopython_version
 from Bio import SeqIO
@@ -441,7 +441,7 @@ def annotate_with_eggnog(input_folder, output_folder, eggnog_database_path, nb_c
     options['tool_dependencies']['python_package']['Python_version'] = sys.version
     options['tool_dependencies']['python_package']['esmecata'] = esmecata_version
     options['tool_dependencies']['python_package']['pandas'] = pd.__version__
-    options['tool_dependencies']['python_package']['ete3'] = ete3_version
+    options['tool_dependencies']['python_package']['ete4'] = ete4_version
     options['tool_dependencies']['python_package']['biopython'] = biopython_version
     options['tool_dependencies']['eggnog_mapper'] = get_eggnog_version()
 

--- a/esmecata/core/precomputed.py
+++ b/esmecata/core/precomputed.py
@@ -27,8 +27,8 @@ import zipfile
 
 from io import TextIOWrapper
 
-from ete3 import __version__ as ete3_version
-from ete3 import NCBITaxa
+from ete4 import __version__ as ete3_version
+from ete4 import NCBITaxa
 from Bio import SeqIO
 from Bio import __version__ as biopython_version
 

--- a/esmecata/core/precomputed.py
+++ b/esmecata/core/precomputed.py
@@ -27,7 +27,7 @@ import zipfile
 
 from io import TextIOWrapper
 
-from ete4 import __version__ as ete3_version
+from ete4 import __version__ as ete_version
 from ete4 import NCBITaxa
 from Bio import SeqIO
 from Bio import __version__ as biopython_version
@@ -151,7 +151,7 @@ def precomputed_parse_affiliation(input_file, database_taxon_file_path, output_f
     options['tool_dependencies']['python_package'] = {}
     options['tool_dependencies']['python_package']['Python_version'] = sys.version
     options['tool_dependencies']['python_package']['esmecata'] = esmecata_version
-    options['tool_dependencies']['python_package']['ete3'] = ete3_version
+    options['tool_dependencies']['python_package']['ete4'] = ete_version
     options['tool_dependencies']['python_package']['pandas'] = pd.__version__
     options['tool_dependencies']['python_package']['biopython'] = biopython_version
 
@@ -213,7 +213,7 @@ def precomputed_parse_affiliation(input_file, database_taxon_file_path, output_f
 
     ncbi = NCBITaxa()
 
-    # Parse taxonomic affiliations with ete3 to find matching taxon name.
+    # Parse taxonomic affiliations with ete4 to find matching taxon name.
     tax_id_names, json_taxonomic_affiliations = associate_taxon_to_taxon_id(taxonomies, update_affiliations, ncbi, output_folder)
 
     # Disambiguate taxon name using other taxon from the taxonomic affiliations.

--- a/esmecata/core/proteomes.py
+++ b/esmecata/core/proteomes.py
@@ -38,8 +38,8 @@ from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
-from ete3 import __version__ as ete3_version
-from ete3 import NCBITaxa, is_taxadb_up_to_date
+from ete4 import __version__ as ete4_version
+from ete4 import NCBITaxa, is_taxadb_up_to_date
 
 from SPARQLWrapper import __version__ as sparqlwrapper_version
 
@@ -99,8 +99,8 @@ def get_batch(session, batch_url):
         batch_url = get_next_link(response.headers)
 
 
-def ete3_database_update(ignore_taxadb_update):
-    """ Check if ete3 taxa database is up to date, if not update it.
+def ete_database_update(ignore_taxadb_update):
+    """ Check if ete4 taxa database is up to date, if not update it.
 
     Args:
         ignore_taxadb_update (bool): if True, ignore the need to update database.
@@ -116,7 +116,7 @@ def ete3_database_update(ignore_taxadb_update):
     if ete_taxadb_up_to_date is False:
         logger.warning('|EsMeCaTa|proteomes| WARNING: ncbi taxonomy database is not up to date with the last NCBI Taxonomy. It will be updated')
         if ignore_taxadb_update is None:
-            logger.info('|EsMeCaTa|proteomes| Ete3 taxa database will be updated.')
+            logger.info('|EsMeCaTa|proteomes| Ete4 taxa database will be updated.')
             ncbi = NCBITaxa()
             ncbi.update_taxonomy_database()
         else:
@@ -124,12 +124,12 @@ def ete3_database_update(ignore_taxadb_update):
 
 
 def update_taxonomy(observation_name, taxonomic_affiliation, ncbi=None):
-    """ Update the taxonomic affiliation using ete3 and the lowest available taxonomic name.
+    """ Update the taxonomic affiliation using ete4 and the lowest available taxonomic name.
 
     Args:
         observation_name (str): observation name associated with taxonomic affiliation
         taxonomic_affiliation (str): str with taxon from highest taxon (such as kingdom) to lowest (such as species)
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
 
     Returns:
         new_taxonomic_affiliations (str): str with taxon from highest taxon (such as kingdom) to lowest (such as species)
@@ -137,7 +137,7 @@ def update_taxonomy(observation_name, taxonomic_affiliation, ncbi=None):
     if ncbi is None:
         ncbi = NCBITaxa()
 
-    # For each taxon in the affiliation, search for the lineage associated in ete3.
+    # For each taxon in the affiliation, search for the lineage associated in ete4.
     lineage_all_taxa = []
     taxons = [taxon for taxon in taxonomic_affiliation.split(';')]
     for taxon in reversed(taxons):
@@ -212,7 +212,7 @@ def taxonomic_affiliation_to_taxon_id(observation_name, taxonomic_affiliation, n
     Args:
         observation_name (str): observation name associated with taxonomic affiliation
         taxonomic_affiliation (str): str with taxon from highest taxon (such as kingdom) to lowest (such as species)
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
     Returns:
         tax_ids_to_names (dict): mapping between taxon ID and taxon name
         taxon_ids (dict): mapping between taxon name and taxon ID
@@ -226,7 +226,7 @@ def taxonomic_affiliation_to_taxon_id(observation_name, taxonomic_affiliation, n
     for taxon in taxons:
         taxon_translations = ncbi.get_name_translator([taxon])
         if taxon_translations == {}:
-            logger.critical('|EsMeCaTa|proteomes| For %s, no taxon ID has been found associated with the taxon "%s" in the NCBI taxonomy of ete3.', observation_name, taxon)
+            logger.critical('|EsMeCaTa|proteomes| For %s, no taxon ID has been found associated with the taxon "%s" in the NCBI taxonomy of ete4.', observation_name, taxon)
             taxon_translations = {taxon: ['not_found']}
         taxon_ids.update(taxon_translations)
     tax_ids_to_names = {v: k for k, vs in tax_names_to_ids.items() for v in vs }
@@ -240,7 +240,7 @@ def associate_taxon_to_taxon_id(taxonomic_affiliations, update_affiliations=None
     Args:
         taxonomic_affiliations (dict): dictionary with observation name as key and taxonomic affiliation as value
         update_affiliations (str): option to update taxonomic affiliations.
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database.
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database.
         output_folder (str): pathname to output folder.
 
     Returns:
@@ -284,7 +284,7 @@ def disambiguate_taxon(json_taxonomic_affiliations, ncbi):
 
     Args:
         json_taxonomic_affiliations (dict): observation name and dictionary with mapping betwenn taxon name and taxon ID
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
     Returns:
         json_taxonomic_affiliations (dict): observation name and dictionary with mapping betwenn taxon name and taxon ID (disambiguated)
     """
@@ -337,7 +337,7 @@ def filter_rank_limit(json_taxonomic_affiliations, ncbi, rank_limit):
 
     Args:
         json_taxonomic_affiliations (dict): observation name and dictionary with mapping betwenn taxon name and taxon ID
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
         rank_limit (str): rank limit to filter the affiliations (keep this rank and all inferior ranks)
     Returns:
         output_json_taxonomic_affiliations (dict): observation name and dictionary with mapping betwenn taxon name and taxon ID (with remove rank specified)
@@ -720,13 +720,13 @@ def sparql_query_proteomes(observation_name, tax_id, tax_name, busco_percentage_
 
 
 def compare_input_taxon_with_esmecata(json_taxonomic_affiliations, proteomes_ids, ncbi):
-    """Search the taxonomic affiliations found by ete3 to find the lowest tax rank associated with each observation_name.
+    """Search the taxonomic affiliations found by ete4 to find the lowest tax rank associated with each observation_name.
     Then look at esmecata to find the taxon rank used to find proteome.
 
     Args:
         json_taxonomic_affiliations (dict): observation name and dictionary with mapping between taxon name and taxon ID (with remove rank specified)
         proteomes_ids (dict):  observation name (key) associated with proteome IDs
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
 
     Returns:
         taxon_rank_comparison (dict): lowest taxon name in input affiliation (key) associated with dict containing associated taxon ranks found by esmecata and the corresponding occurrence
@@ -751,7 +751,7 @@ def compare_input_taxon_with_esmecata(json_taxonomic_affiliations, proteomes_ids
                         lowest_tax_rank = higher_tax_rank
                     break
 
-        # If no taxon identified by ete3 is found, classified it as not_found.
+        # If no taxon identified by ete4 is found, classified it as not_found.
         if lowest_tax_rank is None:
             lowest_tax_rank = 'not_found'
 
@@ -856,7 +856,7 @@ def subsampling_proteomes(organism_ids, limit_maximal_number_proteomes, ncbi):
     Args:
         organism_ids (dict): organism ID as key and the proteome IDs associated with it as value
         limit_maximal_number_proteomes (int): int threshold after which a subsampling will be performed on the data
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
 
     Returns:
         selected_proteomes (list): subsample proteomes selected by the methods
@@ -864,15 +864,15 @@ def subsampling_proteomes(organism_ids, limit_maximal_number_proteomes, ncbi):
     try:
         tree = ncbi.get_topology([org_tax_id for org_tax_id in organism_ids])
     except KeyError:
-        logger.critical('|EsMeCaTa|proteomes| UniProt tax ID not in ete3 NCBI Taxonomy database. Try to update it with the following command: python3 -c "from ete3 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database()".')
+        logger.critical('|EsMeCaTa|proteomes| UniProt tax ID not in ete4 NCBI Taxonomy database. Try to update it with the following command: python3 -c "from ete4 import NCBITaxa; ncbi = NCBITaxa(); ncbi.update_taxonomy_database()".')
         raise KeyError()
 
     # For each direct descendant taxon of the tree root (our tax_id), we will look for the proteomes inside these subtaxons.
     childs = {}
     for parent_node in tree.get_children():
         parent_tax_id = str(parent_node.taxid)
-        if parent_node.get_descendants() != []:
-            for child_node in parent_node.get_descendants():
+        if parent_node.descendants() != []:
+            for child_node in parent_node.descendants():
                 child_tax_id = str(child_node.taxid)
                 if parent_tax_id not in childs:
                     if child_tax_id in organism_ids:
@@ -918,7 +918,7 @@ def find_proteomes_tax_ids(json_taxonomic_affiliations, ncbi, proteomes_descript
 
     Args:
         json_taxonomic_affiliations (dict): observation name and dictionary with mapping between taxon name and taxon ID (with remove rank specified)
-        ncbi (ete3.NCBITaxa()): ete3 NCBI database
+        ncbi (ete4.NCBITaxa()): ete4 NCBI database
         proteomes_description_folder (str): pathname to the proteomes_description_folder
         busco_percentage_keep (float): BUSCO score to filter proteomes (proteomes selected will have a higher BUSCO score than this threshold)
         all_proteomes (bool): Option to select all the proteomes (and not only preferentially reference proteomes)
@@ -1299,7 +1299,7 @@ def check_proteomes(input_file, output_folder, busco_percentage_keep=80,
         input_file (str): pathname to the tsv input file containing taxonomic affiliations.
         output_folder (str): pathname to the output folder.
         busco_percentage_keep (float): BUSCO score to filter proteomes (proteomes selected will have a higher BUSCO score than this threshold).
-        ignore_taxadb_update (bool): option to ignore ete3 taxa database update.
+        ignore_taxadb_update (bool): option to ignore ete4 taxa database update.
         all_proteomes (bool): Option to select all the proteomes (and not only preferentially reference proteomes).
         uniprot_sparql_endpoint (str): uniprot SPARQL endpoint to query (by default query Uniprot SPARQL endpoint).
         limit_maximal_number_proteomes (int): int threshold after which a subsampling will be performed on the data.
@@ -1320,7 +1320,7 @@ def check_proteomes(input_file, output_folder, busco_percentage_keep=80,
         logger.critical('|EsMeCaTa|proteomes| The input %s is not a valid file pathname.', input_file)
         sys.exit()
 
-    ete3_database_update(ignore_taxadb_update)
+    ete_database_update(ignore_taxadb_update)
 
     if minimal_number_proteomes >= limit_maximal_number_proteomes:
         logger.critical('|EsMeCaTa|proteomes| Error minimal_number_proteomes (%d) can not be superior or equal to limit_maximal_number_proteomes (%d).', minimal_number_proteomes, limit_maximal_number_proteomes)
@@ -1503,7 +1503,7 @@ def retrieve_proteomes(input_file, output_folder, busco_percentage_keep=80,
         input_file (str): pathname to the tsv input file containing taxonomic affiliations.
         output_folder (str): pathname to the output folder.
         busco_percentage_keep (float): BUSCO score to filter proteomes (proteomes selected will have a higher BUSCO score than this threshold).
-        ignore_taxadb_update (bool): option to ignore ete3 taxa database update.
+        ignore_taxadb_update (bool): option to ignore ete4 taxa database update.
         all_proteomes (bool): Option to select all the proteomes (and not only preferentially reference proteomes).
         uniprot_sparql_endpoint (str): uniprot SPARQL endpoint to query (by default query Uniprot SPARQL endpoint).
         limit_maximal_number_proteomes (int): int threshold after which a subsampling will be performed on the data.
@@ -1587,7 +1587,7 @@ def retrieve_proteomes(input_file, output_folder, busco_percentage_keep=80,
     options['tool_dependencies']['python_package']['Python_version'] = sys.version
     options['tool_dependencies']['python_package']['biopython'] = biopython_version
     options['tool_dependencies']['python_package']['esmecata'] = esmecata_version
-    options['tool_dependencies']['python_package']['ete3'] = ete3_version
+    options['tool_dependencies']['python_package']['ete4'] = ete4_version
     options['tool_dependencies']['python_package']['pandas'] = pd.__version__
     options['tool_dependencies']['python_package']['requests'] = requests.__version__
     options['tool_dependencies']['python_package']['SPARQLWrapper'] = sparqlwrapper_version

--- a/esmecata/core/workflow.py
+++ b/esmecata/core/workflow.py
@@ -93,7 +93,7 @@ def perform_workflow(input_file, output_folder, busco_percentage_keep=80, ignore
         input_file (str): pathname to the tsv input file containing taxonomic affiliations
         output_folder (str): pathname to the output folder
         busco_percentage_keep (float): BUSCO score to filter proteomes (proteomes selected will have a higher BUSCO score than this threshold)
-        ignore_taxadb_update (bool): option to ignore ete3 taxa database update
+        ignore_taxadb_update (bool): option to ignore ete4 taxa database update
         all_proteomes (bool): Option to select all the proteomes (and not only preferentially reference proteomes)
         uniprot_sparql_endpoint (str): uniprot SPARQL endpoint to query (by default query Uniprot SPARQL endpoint)
         remove_tmp (bool): remove the tmp files
@@ -178,7 +178,7 @@ def perform_workflow_eggnog(input_file, output_folder, eggnog_database_path, bus
         output_folder (str): pathname to the output folder
         eggnog_database_path (str): pathname to eggnog database folder
         busco_percentage_keep (float): BUSCO score to filter proteomes (proteomes selected will have a higher BUSCO score than this threshold)
-        ignore_taxadb_update (bool): option to ignore ete3 taxa database update
+        ignore_taxadb_update (bool): option to ignore ete4 taxa database update
         all_proteomes (bool): Option to select all the proteomes (and not only preferentially reference proteomes)
         uniprot_sparql_endpoint (str): uniprot SPARQL endpoint to query (by default query Uniprot SPARQL endpoint)
         remove_tmp (bool): remove the tmp files

--- a/esmecata/precomputed/create_database.py
+++ b/esmecata/precomputed/create_database.py
@@ -204,7 +204,7 @@ def create_database_from_run(esmecata_proteomes_folder, esmecata_clustering_fold
     tax_id_issues = {}
     # Parse all descendant of root to search for children tax id with lower protein than parents.
     # To identify taxon with potential errors.
-    for descendant in database_tree.iter_descendants():
+    for descendant in database_tree.descendants():
         descendant_childrens = descendant.children
         parent_tax_id = int(descendant.name)
         if parent_tax_id in tax_id_protein_clusters:

--- a/esmecata/precomputed/create_database.py
+++ b/esmecata/precomputed/create_database.py
@@ -25,7 +25,7 @@ from esmecata.core.eggnog import get_proteomes_tax_id_name
 from multiprocessing import Pool
 from collections import Counter
 
-from ete3 import NCBITaxa
+from ete4 import NCBITaxa
 
 logger = logging.getLogger(__name__)
 

--- a/esmecata/precomputed/create_input_precomputation.py
+++ b/esmecata/precomputed/create_input_precomputation.py
@@ -15,7 +15,9 @@
 import csv
 from esmecata.utils import send_uniprot_sparql_query
 
-from ete3 import NCBITaxa
+from ete4 import NCBITaxa
+
+
 def get_taxon_proteomes(output_file, taxon_rank='Genus'):
     uniprot_sparql_endpoint='https://sparql.uniprot.org/sparql'
 

--- a/esmecata/report/esmecata2taxontology.py
+++ b/esmecata/report/esmecata2taxontology.py
@@ -17,7 +17,7 @@ import csv
 import os.path
 
 import plotly.graph_objects as go
-from ete3 import NCBITaxa
+from ete4 import NCBITaxa
 from typing import Dict, List, Set, Tuple
 
 from esmecata.report.esmecata_compression import RANK2COL

--- a/esmecata/report/esmecata_compression.py
+++ b/esmecata/report/esmecata_compression.py
@@ -28,7 +28,7 @@ import pandas as pd
 # --------------------------------
 
 RANK2COL = {  # KINGDOM (RED)
-    'superkingdom': '#6f1a12', 'kingdom': '#872015', 'subkingdom': '#a2261a',
+    'superkingdom': '#6f1a12', 'domain': '#6f1a12', 'kingdom': '#872015', 'subkingdom': '#a2261a',
     # PHYLUM (ORANGE)
     'superphylum': '#b26f15', 'phylum': '#c87c14', 'subphylum': '#de8710', 'infraphylum': '#fa960e',
     # CLASS (YELLOW)
@@ -68,7 +68,7 @@ RANK_SORTED = ['isolate', 'strain', 'serotype', 'serogroup', 'forma', 'subvariet
                'subcohort', 'cohort',
                'infraclass', 'subclass', 'class', 'superclass',
                'infraphylum', 'subphylum', 'phylum', 'superphylum',
-               'subkingdom', 'kingdom', 'superkingdom',
+               'subkingdom', 'kingdom', 'superkingdom', 'domain',
                'clade', 'environmental samples', 'incertae sedis', 'unclassified', 'no rank']
 
 # FIGURE COMPOSITION CONSTANTS

--- a/esmecata/report/panel_report_creation.py
+++ b/esmecata/report/panel_report_creation.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2023-2025 Pauline Hamon-Giraud and Alice Mataigne - Inria, Univ Rennes, CNRS, IRISA Dyliss
+# Arnaud Belcour - Univ. Grenoble Alpes, Inria, Microcosme
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>
+
+from bokeh.resources import INLINE, CDN
+import panel as pn
+
+
+def create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
+                        fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
+                        fig12, fig12_details, metadata, output_file, reduce=None):
+    """ Create HTML report using panel from plotly figures.
+    This function was created as a temporary fix after datapane was no longer maintained.
+    Now it is replaced by the function using arakawa report. 
+
+    Args:
+        CONFIG (dict): metadata dictionary for plotly.
+        DATA (dict): gathers all useful data for the analysis of an esmecata run (inputs, summary tables, taxonomy ...)
+        DATA2 (dict): dictionary storing dataframes corresponding to EC number with summary numbers
+        DATA3 (dict): dictionary storing dataframes corresponding to GO terms with summary numbers
+        fig1 (plotly figure): histogram showing the distribution of proteomes according to taxonomic rank
+        fig4 (plotly figure): heatmap showing how many input taxonomic ranks were assigned to the same rank by esmecata and how many were assigned to higher ranks
+        fig5 (plotly figure): scatterplot showing the frequency of each EC in taxa
+        fig5b (plotly figure): scatterplot showing the frequency of each GO Term in taxa
+        fig6 (plotly figure): scatterplot showing the fraction of all EC of the dataset in each taxa
+        fig6b (plotly figure): scatterplot showing the fraction of all GO Term of the dataset in each taxa
+        fig7 (plotly figure): histogram showing how many EC numbers belongs to each taxa of this rank
+        fig7b (plotly figure): histogram showing how many GO Terms belongs to each taxa of this rank
+        fig8 (plotly figure): histogram of the fraction of all ECs of the dataset in each taxa
+        fig8b (plotly figure): histogram of the fraction of all GO Terms of the dataset in each taxa
+        fig9 (plotly figure): sunburst representing the taxonomic variety of taxa in the dataset.
+        fig10 (plotly figure): sankey graph showing compression and taxonomic ranks rearrangement between input and output taxa of an Esmecata run
+        fig10a (plotly figure): barplot showing the number proteomes according to the taxonomic rank
+        fig11 (plotly figure): sunburst summarizing EC numbers categories, counts and proportions for the whole dataset
+        fig12 (plotly figure): scatterplot showing the representativeness ratio and the number of associated protein clusters according to the taxonomic rank
+        fig12_details (plotly figure): scatterplot showing details of the representativeness ratio and the number of associated protein clusters according to each cluster
+        metadata (dict): all metadata of the workflow (made by merging esmecata metadata json from proteomes, clustering and annotation)
+        output_file (str): path to HTML output file
+    """
+    styles = {
+        'background-color': '#F6F6F6', 'border': '2px solid black',
+        'border-radius': '5px', 'padding': '10px'
+    }
+
+    page_one = pn.Column(
+        pn.pane.Markdown("""# Reduction of taxonomic diversity between EsMeCaTa's inputs and outputs
+                    The sunburst below displays the taxonomic diversity of inputs, i.e. all the taxonomic affiliations listed in the tsv input file. White cells indicates inputs whose ranks were not retained by EsMeCaTa, which went up to the superior taxonomic rank to find proteomes.""",
+                    styles=styles, renderer='markdown'),
+        pn.Column('## Sunburst of taxon selected by EsMeCaTa',
+            pn.pane.Plotly(fig9.update_layout(autosize=True)),
+            sizing_mode='scale_both'),
+
+        pn.pane.Markdown("""# \"Compression\" of taxonomic diversity between inputs and outputs
+                    The sankey diagram below also displays the initial taxonomic diversity of taxonomic affiliations given to EsMeCaTa as inputs. The first column details the content of the input file : one block is equivalent to one taxonomic affiliation, and the block height indicates the number of times this affiliation appears in the input file. The second column details which of these taxonomic affiliations were merged together (i.e. 'compressed') because their taxonomyies were identical in the input file. Finally, The first column displays the ranks EsMeCaTa attributed to each of them : at this step, some taxonomic affiliations can be merged because EsMeCaTa went up the taxonomic ranks to find proteomes.""", styles=styles),
+        pn.Column('## Sankey diagram of taxonomic compression',
+            pn.pane.Plotly(fig10.update_layout(autosize=True)),
+            sizing_mode='scale_both'),
+    )
+    page_two = pn.Column(
+        pn.pane.Markdown("""# Proteomes summary
+                     When proteomes of the lowest taxonomic rank of an input taxa are not found, EsMeCaTa goes up in the taxonomic levels to found suited proteomes. In complement to the figures in the first panel, the heatmap below details the difference between the lowest taxonomic rank of all input taxonomic observations (y-axis) and the lowest rank atributed by EsMeCaTa (x-axis).""", styles=styles),
+        pn.Column('## Input and output ranks difference',
+            pn.pane.Plotly(fig4.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+        pn.pane.HTML("""<p>The barplot belows details how many proteomes were assigned to inputs taxonomic affiliations (grouped and colored by phylum). The number of proteomes found can vary from only a few to dozens or hundreds, depending on the data available on UniProt for each taxonomic group.</p>""", styles=styles),
+        pn.Column('## Distribution of the number of proteomes found',
+            pn.pane.Plotly(fig1.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+        pn.Column('## Distribution of proteomes according to taxonomic ranks',
+            pn.pane.Plotly(fig10a.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+    )
+    page_three = pn.Column(
+            pn.pane.HTML("""<h2>Clustering summary</h2>
+                         <p>In the clustering step, for the set of proteomes associated to each input taxa, EsMeCaTa searches for clusters of similar proteic sequences among these proteomes. This step is supervised by a threshold between 0 and 1, 1 meaning that a cluster contains sequences from each proteomes, 0.5 meaning that a cluster contains sequences from at least a half of the proteomes (etc). This threshold can then be an approximation of the pan-proteome (0) and the core-proteome (1). Clusters below the threshold are discarded. The figure below displays how many clusters were retained at each threshold value. The vertical red line displays the threshold set dor this run of EsMeCata.</p>""", styles=styles),
+        pn.Column('## Proteomes representativeness',
+            pn.pane.Plotly(fig12.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+        pn.Column('## Proteomes representativeness details',
+            pn.pane.Plotly(fig12_details.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+    )
+    page_four = pn.Column(
+        # EC numbers figures
+        pn.FlexBox(
+            pn.pane.HTML("""<h2>EC numbers frequencies among taxa</h2>
+                        <p>Numbers and figures below detail how EC numbers vary among taxa, i.e. if an EC number is found in many taxa (a generic EC number) or only in very few taxa (a specific EC number).</p>""", styles=styles),
+            pn.indicators.Number(name='EC found in more than 90% of taxa', value=DATA2["n_9_an"], format='{value}'),
+            pn.indicators.Number(name='EC found in less than 10% of taxa', value=DATA2["n_1_an"], format='{value}'),
+            pn.indicators.Number(name='EC found between 10% and 90% of taxa', value=DATA2["n91_an"], format='{value}'),
+        ),
+        pn.Column(
+            pn.Column('## EC numbers frequencies in observations',
+                pn.pane.Plotly(fig5.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+            pn.Column('## EC numbers frequencies in observations (barplot version)',
+                pn.pane.Plotly(fig7.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+        ),
+
+        pn.FlexBox(
+            pn.pane.HTML("""<h2>Taxa content in EC numbers</h2>
+                        <p>Numbers and figures below detail which taxa are annotated with most of the EC numbers of the whole dataset or only a few EC numbers. For instance, taxa with many EC numbers could have bigger genomes or be generalist species.</p>""", styles=styles),
+            pn.indicators.Number(name="Taxa with more than 90% of all the dataset's EC numbers", value=DATA2["n_9_ob"], format='{value}'),
+            pn.indicators.Number(name="Taxa with less than 10% of all the dataset's EC numbers", value=DATA2["n_1_ob"], format='{value}'),
+            pn.indicators.Number(name="Taxa with between 10% and 90% of all the dataset's EC numbers", value=DATA2["n91_ob"], format='{value}'),
+        ),
+        pn.Column(
+            pn.Column('## Taxa content in EC numbers',
+                pn.pane.Plotly(fig6.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+            pn.Column('## Taxa content in EC numbers (barplot version)',
+                pn.pane.Plotly(fig8.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+        ),
+
+        pn.pane.HTML("<h2>EC numbers classes, counts and proportions</h2>", styles=styles),
+        pn.Column('## EC numbers classes, counts and proportions',
+            pn.pane.Plotly(fig11.update_layout(modebar=CONFIG, autosize=True)),
+            sizing_mode='scale_both'),
+
+        # GO terms figures
+        pn.FlexBox(
+            pn.pane.HTML("""<h2>GO terms frequencies among taxa</h2>
+                        <p>Numbers and figures below detail how GO terms vary among taxa, i.e. if a GO term is found in many taxa (a generic GO term) or only in very few taxa (a specific GO term).</p>""", styles=styles),
+            pn.indicators.Number(name="GO terms found in more than 90% of taxa", value=DATA3["n_9_an"], format='{value}'),
+            pn.indicators.Number(name="GO terms found in less than 10% of taxa", value=DATA3["n_1_an"], format='{value}'),
+            pn.indicators.Number(name="GO terms found between 10% and 90% of taxa", value=DATA3["n91_an"], format='{value}'),
+        ),
+        pn.Column(
+            pn.Column('## GO terms frequencies in taxa',
+                pn.pane.Plotly(fig5b.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+            pn.Column('## GO terms frequencies in taxa (barplot version)',
+                pn.pane.Plotly(fig7b.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+        ),
+
+        pn.FlexBox(
+        pn.pane.HTML("""<h2>Taxa content in GO terms</h2>
+                     <p>Numbers and figures below detail which taxa are annotated with most of the GO terms of the whole dataset or only a few Go terms. For instance, taxa with many Go terms could have bigger genomes or be generalist species.</p>""", styles=styles),
+            pn.indicators.Number(name="Taxa with more than 90% of all the dataset's GO terms", value=DATA3["n_9_ob"], format='{value}'),
+            pn.indicators.Number(name="Taxa with less than 10% of all the dataset's GO terms", value=DATA3["n_1_ob"], format='{value}'),
+            pn.indicators.Number(name="Taxa with between 10% and 90% of all the dataset's GO terms", value=DATA3["n91_ob"], format='{value}'),
+        ),
+        pn.Column(
+            pn.Column("## Observations' content in GO terms",
+                pn.pane.Plotly(fig6b.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+            pn.Column("## Observations' content in GO terms (barplot version)",
+                pn.pane.Plotly(fig8b.update_layout(modebar=CONFIG, autosize=True)),
+                sizing_mode='scale_both'),
+        ),
+        height=5000
+    )
+
+    if not DATA["DISCARDED"].empty:    
+        discarded_panel_content_panel = pn.pane.DataFrame(DATA["DISCARDED"])
+    else:
+        discarded_panel_content_panel =  pn.pane.HTML("<p>None of input the taxonomic observations were discarded</p>", styles=styles)
+
+    page_five = pn.Column(
+                pn.FlexBox(
+                    pn.indicators.Number(name="Number of inputs", value=DATA["N_IN"], format='{value}'),
+                    pn.indicators.Number(name="Kept by EsMeCaTa", value=DATA["N_OUT"], format='{value}'),
+                    pn.indicators.Number(name="Discarded", value=DATA["N_DISCARDED"], format='{value}'),
+                ),
+                pn.FlexBox(
+                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>", styles=styles),
+                    pn.pane.DataFrame(DATA["DF_STATS"]),
+                ),
+                pn.FlexBox(
+                    pn.pane.HTML("<h2>Discarded</h2><p>Taxonomic ranks were not inferred; only names are displayed</p>", styles=styles),
+                    discarded_panel_content_panel
+                ),
+    )
+
+    page_six = pn.Column(
+        pn.pane.JSON(metadata, name="Metadata", depth=-1),
+    )
+
+    tabs = pn.Tabs(("Inputs and outputs ranks comparison", page_one),
+                   ("Proteomes summary", page_two),
+                   ("Clustering summary", page_three),
+                   ("Annotation summary", page_four),
+                   ("Data summary", page_five),
+                   ("Metadata", page_six),
+                   height_policy="fit", sizing_mode="fixed")
+
+    panel = pn.template.VanillaTemplate(
+        title="EsMeCaTa report",
+        main=[tabs],
+        header_color='black',
+        header_background='white'
+    )
+ 
+    if reduce is True:
+        panel.save(output_file, resources=CDN)
+    else:
+        panel.save(output_file, resources=INLINE)
+

--- a/esmecata/report/panel_report_creation.py
+++ b/esmecata/report/panel_report_creation.py
@@ -179,7 +179,7 @@ def create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig
                     pn.indicators.Number(name="Discarded", value=DATA["N_DISCARDED"], format='{value}'),
                 ),
                 pn.FlexBox(
-                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>", styles=styles),
+                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete4</p>", styles=styles),
                     pn.pane.DataFrame(DATA["DF_STATS"]),
                 ),
                 pn.FlexBox(

--- a/esmecata/report/report_creation.py
+++ b/esmecata/report/report_creation.py
@@ -17,7 +17,7 @@
 
 import os
 import json
-import datapane as dp
+import arakawa as ar
 
 from plotly.io import write_json
 
@@ -196,157 +196,158 @@ def create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig
         panel.save(output_file, resources=INLINE)
 
 
-def create_datapane_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
+def create_arakawa_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
                         fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
                         fig12, fig12_details, metadata, output_file):
     print("Formatting summary dataframes")
     if not DATA["DISCARDED"].empty:    
-        df_discarded_panel_content = dp.DataTable(DATA["DISCARDED"],label="Data")
+        df_discarded_panel_content = ar.DataTable(DATA["DISCARDED"],label="Data")
     else:
-        df_discarded_panel_content = dp.HTML("<p>None of input the taxonomic observations were discarded</p>")
+        df_discarded_panel_content = ar.HTML("<p>None of input the taxonomic observations were discarded</p>")
 
-    report = dp.Blocks(
+    report = ar.Blocks(
 
         # Page 1 : EsMeCaTa's inputs and outputs taxonomic ranks
-        dp.Page(
+        ar.Page(
             title="Inputs and outputs ranks comparison",
             blocks=[
-                dp.HTML("<h2>Reduction of taxonomic diversity between EsMeCaTa's inputs and outputs</h2>"),
-                dp.HTML("<p>The sunburst below displays the taxonomic diversity of inputs, i.e. all the taxonomic affiliations listed in the tsv input file. White cells indicates inputs whose ranks were not retained by EsMeCaTa, which went up to the superior taxonomic rank to find proteomes.</p>"),           
-                dp.Plot(fig9), #.update_traces(marker=dict(pattern=dict(shape=tmp_data['Shape'])))),
-                dp.HTML("<h2>\"Compression\" of taxonomic diversity between inputs and outputs</h2>"),
-                dp.HTML("<p>The sankey diagram below also displays the initial taxonomic diversity of taxonomic affiliations given to EsMeCaTa as inputs. The first column details the content of the input file : one block is equivalent to one taxonomic affiliation, and the block height indicates the number of times this affiliation appears in the input file. The second column details which of these taxonomic affiliations were merged together (i.e. 'compressed') because their taxonomyies were identical in the input file. Finally, The first column displays the ranks EsMeCaTa attributed to each of them : at this step, some taxonomic affiliations can be merged because EsMeCaTa went up the taxonomic ranks to find proteomes.</p>"),
-                dp.Plot(fig10, label='Taxonomic compression')
+                ar.HTML("<h2>Reduction of taxonomic diversity between EsMeCaTa's inputs and outputs</h2>"),
+                ar.HTML("<p>The sunburst below displays the taxonomic diversity of inputs, i.e. all the taxonomic affiliations listed in the tsv input file. White cells indicates inputs whose ranks were not retained by EsMeCaTa, which went up to the superior taxonomic rank to find proteomes.</p>"),           
+                ar.Plot(fig9), #.update_traces(marker=dict(pattern=dict(shape=tmp_data['Shape'])))),
+                ar.HTML("<h2>\"Compression\" of taxonomic diversity between inputs and outputs</h2>"),
+                ar.HTML("<p>The sankey diagram below also displays the initial taxonomic diversity of taxonomic affiliations given to EsMeCaTa as inputs. The first column details the content of the input file : one block is equivalent to one taxonomic affiliation, and the block height indicates the number of times this affiliation appears in the input file. The second column details which of these taxonomic affiliations were merged together (i.e. 'compressed') because their taxonomyies were identical in the input file. Finally, The first column displays the ranks EsMeCaTa attributed to each of them : at this step, some taxonomic affiliations can be merged because EsMeCaTa went up the taxonomic ranks to find proteomes.</p>"),
+                ar.Plot(fig10, label='Taxonomic compression')
             ],
         ),
 
         # Step 1 (Page 2) : EsMeCaTa proteomes
-        dp.Page(
+        ar.Page(
             title="Proteomes summary",
             blocks=[
-                dp.Group(
-                    dp.HTML("<p>When proteomes of the lowest taxonomic rank of an input taxa are not found, EsMeCaTa goes up in the taxonomic levels to found suited proteomes. In complement to the figures in the first panel, the heatmap below details the difference between the lowest taxonomic rank of all input taxonomic observations (y-axis) and the lowest rank atributed by EsMeCaTa (x-axis).</p>"),
-                    dp.HTML("<p>The barplot belows details how many proteomes were assigned to inputs taxonomic affiliations (grouped and colored by phylum). The number of proteomes found can vary from only a few to dozens or hundreds, depending on the data available on UniProt for each taxonomic group.</p>"),
-                    dp.Plot(fig4.update_layout(modebar=CONFIG), label='Input and output ranks difference'),
-                    dp.Plot(fig1.update_layout(modebar=CONFIG), label='Distribution of the number of proteomes found'),
-                    dp.HTML("<h2>Distribution of proteomes according to taxonomic ranks</h2>"),
-                    dp.Plot(fig10a.update_layout(modebar=CONFIG), label='Distribution of proteomes according to taxonomic ranks'),
+                ar.Group(
+                    ar.HTML("<p>When proteomes of the lowest taxonomic rank of an input taxa are not found, EsMeCaTa goes up in the taxonomic levels to found suited proteomes. In complement to the figures in the first panel, the heatmap below details the difference between the lowest taxonomic rank of all input taxonomic observations (y-axis) and the lowest rank atributed by EsMeCaTa (x-axis).</p>"),
+                    ar.HTML("<p>The barplot belows details how many proteomes were assigned to inputs taxonomic affiliations (grouped and colored by phylum). The number of proteomes found can vary from only a few to dozens or hundreds, depending on the data available on UniProt for each taxonomic group.</p>"),
+                    ar.Plot(fig4.update_layout(modebar=CONFIG), label='Input and output ranks difference'),
+                    ar.Plot(fig1.update_layout(modebar=CONFIG), label='Distribution of the number of proteomes found'),
+                    ar.HTML("<h2>Distribution of proteomes according to taxonomic ranks</h2>"),
+                    ar.Plot(fig10a.update_layout(modebar=CONFIG), label='Distribution of proteomes according to taxonomic ranks'),
                     columns=2,
                 )
             ],
         ),
 
         # Step 2 (Page 3): EsMeCaTa clustering
-        dp.Page(
+        ar.Page(
             title="Clustering summary",
             blocks=[
-                dp.HTML("<p>In the clustering step, for the set of proteomes associated to each input taxa, EsMeCaTa searches for clusters of similar proteic sequences among these proteomes. This step is supervised by a threshold between 0 and 1, 1 meaning that a cluster contains sequences from each proteomes, 0.5 meaning that a cluster contains sequences from at least a half of the proteomes (etc). This threshold can then be an approximation of the pan-proteome (0) and the core-proteome (1). Clusters below the threshold are discarded. The figure below displays how many clusters were retained at each threshold value. The vertical red line displays the threshold set dor this run of EsMeCata.</p>"),
-                dp.Plot(fig12.update_layout(modebar=CONFIG), label='proteomes representativeness'),
-                dp.Plot(fig12_details.update_layout(modebar=CONFIG), label="proteomes representativeness details")
+                ar.HTML("<p>In the clustering step, for the set of proteomes associated to each input taxa, EsMeCaTa searches for clusters of similar proteic sequences among these proteomes. This step is supervised by a threshold between 0 and 1, 1 meaning that a cluster contains sequences from each proteomes, 0.5 meaning that a cluster contains sequences from at least a half of the proteomes (etc). This threshold can then be an approximation of the pan-proteome (0) and the core-proteome (1). Clusters below the threshold are discarded. The figure below displays how many clusters were retained at each threshold value. The vertical red line displays the threshold set dor this run of EsMeCata.</p>"),
+                ar.Plot(fig12.update_layout(modebar=CONFIG), label='proteomes representativeness'),
+                ar.Plot(fig12_details.update_layout(modebar=CONFIG), label="proteomes representativeness details")
             ]
         ),
 
         # Step 3 (Page 4): EsMeCaTa annotation
-        dp.Page(
+        ar.Page(
             title="Annotation summary", 
             blocks=[
 
                 # EC numbers figures
-                dp.HTML("<h2>EC numbers frequencies among taxa</h2>"),
-                dp.HTML("<p>Numbers and figures below detail how EC numbers vary among taxa, i.e. if an EC number is found in many taxa (a generic EC number) or only in very few taxa (a specific EC number).</p>"),
+                ar.HTML("<h2>EC numbers frequencies among taxa</h2>"),
+                ar.HTML("<p>Numbers and figures below detail how EC numbers vary among taxa, i.e. if an EC number is found in many taxa (a generic EC number) or only in very few taxa (a specific EC number).</p>"),
                 
-                dp.Group(
-                    dp.BigNumber(heading="EC found in more than 90% of taxa", value=DATA2["n_9_an"]),
-                    dp.BigNumber(heading="EC found in less than 10% of taxa", value=DATA2["n_1_an"]),
-                    dp.BigNumber(heading="EC found between 10% and 90% of taxa", value=DATA2["n91_an"]),
+                ar.Group(
+                    ar.BigNumber(heading="EC found in more than 90% of taxa", value=DATA2["n_9_an"]),
+                    ar.BigNumber(heading="EC found in less than 10% of taxa", value=DATA2["n_1_an"]),
+                    ar.BigNumber(heading="EC found between 10% and 90% of taxa", value=DATA2["n91_an"]),
                     columns=3,
                 ),
-                dp.Group(
-                    dp.Plot(fig5.update_layout(modebar=CONFIG), label='EC numbers frequencies in observations'),
-                    dp.Plot(fig7.update_layout(modebar=CONFIG), label='EC numbers frequencies in observations (barplot version)'),
+                ar.Group(
+                    ar.Plot(fig5.update_layout(modebar=CONFIG), label='EC numbers frequencies in observations'),
+                    ar.Plot(fig7.update_layout(modebar=CONFIG), label='EC numbers frequencies in observations (barplot version)'),
                     columns=2,
                 ),
 
-                dp.HTML("<h2>Taxa content in EC numbers</h2>"),
-                dp.HTML("<p>Numbers and figures below detail which taxa are annotated with most of the EC numbers of the whole dataset or only a few EC numbers. For instance, taxa with many EC numbers could have bigger genomes or be generalist species.</p>"),
+                ar.HTML("<h2>Taxa content in EC numbers</h2>"),
+                ar.HTML("<p>Numbers and figures below detail which taxa are annotated with most of the EC numbers of the whole dataset or only a few EC numbers. For instance, taxa with many EC numbers could have bigger genomes or be generalist species.</p>"),
                 
-                dp.Group(
-                    dp.BigNumber(heading="Taxa with more than 90% of all the dataset's EC numbers", value=DATA2["n_9_ob"]),
-                    dp.BigNumber(heading="Taxa with less than 10% of all the dataset's EC numbers", value=DATA2["n_1_ob"]),
-                    dp.BigNumber(heading="Taxa with between 10% and 90% of all the dataset's EC numbers", value=DATA2["n91_ob"]),
+                ar.Group(
+                    ar.BigNumber(heading="Taxa with more than 90% of all the dataset's EC numbers", value=DATA2["n_9_ob"]),
+                    ar.BigNumber(heading="Taxa with less than 10% of all the dataset's EC numbers", value=DATA2["n_1_ob"]),
+                    ar.BigNumber(heading="Taxa with between 10% and 90% of all the dataset's EC numbers", value=DATA2["n91_ob"]),
                     columns=3,
                 ),
-                dp.Group(
-                    dp.Plot(fig6.update_layout(modebar=CONFIG), label="Taxa content in EC numbers"),
-                    dp.Plot(fig8.update_layout(modebar=CONFIG), label="Taxa content in EC numbers (barplot version)"),
+                ar.Group(
+                    ar.Plot(fig6.update_layout(modebar=CONFIG), label="Taxa content in EC numbers"),
+                    ar.Plot(fig8.update_layout(modebar=CONFIG), label="Taxa content in EC numbers (barplot version)"),
                     columns=2,
                 ),
 
-                dp.HTML("<h2>EC numbers classes, counts and proportions</h2>"),
-                dp.Plot(fig11.update_layout(modebar=CONFIG), label="EC numbers classes, counts and proportions"),
+                ar.HTML("<h2>EC numbers classes, counts and proportions</h2>"),
+                ar.Plot(fig11.update_layout(modebar=CONFIG), label="EC numbers classes, counts and proportions"),
 
                 # GO terms figures
-                dp.HTML("<h2>GO terms frequencies among taxa</h2>"),
-                dp.HTML("<p>Numbers and figures below detail how GO terms vary among taxa, i.e. if a GO term is found in many taxa (a generic GO term) or only in very few taxa (a specific GO term).</p>"),
+                ar.HTML("<h2>GO terms frequencies among taxa</h2>"),
+                ar.HTML("<p>Numbers and figures below detail how GO terms vary among taxa, i.e. if a GO term is found in many taxa (a generic GO term) or only in very few taxa (a specific GO term).</p>"),
                 
-                dp.Group(
-                    dp.BigNumber(heading="GO terms found in more than 90% of taxa", value=DATA3["n_9_an"]),
-                    dp.BigNumber(heading="GO terms found in less than 10% of taxa", value=DATA3["n_1_an"]),
-                    dp.BigNumber(heading="GO terms found between 10% and 90% of taxa", value=DATA3["n91_an"]),
+                ar.Group(
+                    ar.BigNumber(heading="GO terms found in more than 90% of taxa", value=DATA3["n_9_an"]),
+                    ar.BigNumber(heading="GO terms found in less than 10% of taxa", value=DATA3["n_1_an"]),
+                    ar.BigNumber(heading="GO terms found between 10% and 90% of taxa", value=DATA3["n91_an"]),
                     columns=3,
                 ),
-                dp.Group(
-                    dp.Plot(fig5b.update_layout(modebar=CONFIG), label='Go terms frequencies in taxa'),
-                    dp.Plot(fig7b.update_layout(modebar=CONFIG), label='Go terms frequencies in taxa (barplot version)'),
+                ar.Group(
+                    ar.Plot(fig5b.update_layout(modebar=CONFIG), label='Go terms frequencies in taxa'),
+                    ar.Plot(fig7b.update_layout(modebar=CONFIG), label='Go terms frequencies in taxa (barplot version)'),
                     columns=2,
                 ),
 
-                dp.HTML("<h2>Taxa content in GO terms</h2>"),
-                dp.HTML("<p>Numbers and figures below detail which taxa are annotated with most of the GO terms of the whole dataset or only a few Go terms. For instance, taxa with many Go terms could have bigger genomes or be generalist species.</p>"),
+                ar.HTML("<h2>Taxa content in GO terms</h2>"),
+                ar.HTML("<p>Numbers and figures below detail which taxa are annotated with most of the GO terms of the whole dataset or only a few Go terms. For instance, taxa with many Go terms could have bigger genomes or be generalist species.</p>"),
                 
-                dp.Group(
-                    dp.BigNumber(heading="Taxa with more than 90% of all the dataset's GO terms", value=DATA3["n_9_ob"]),
-                    dp.BigNumber(heading="Taxa with less than 10% of all the dataset's GO terms", value=DATA3["n_1_ob"]),
-                    dp.BigNumber(heading="Taxa with between 10% and 90% of all the dataset's GO terms", value=DATA3["n91_ob"]),
+                ar.Group(
+                    ar.BigNumber(heading="Taxa with more than 90% of all the dataset's GO terms", value=DATA3["n_9_ob"]),
+                    ar.BigNumber(heading="Taxa with less than 10% of all the dataset's GO terms", value=DATA3["n_1_ob"]),
+                    ar.BigNumber(heading="Taxa with between 10% and 90% of all the dataset's GO terms", value=DATA3["n91_ob"]),
                     columns=3,
                 ),
-                dp.Group(
-                    dp.Plot(fig6b.update_layout(modebar=CONFIG), label="Observations' content in GO terms"),
-                    dp.Plot(fig8b.update_layout(modebar=CONFIG), label="Observations' content in GO terms (barplot version)"),
+                ar.Group(
+                    ar.Plot(fig6b.update_layout(modebar=CONFIG), label="Observations' content in GO terms"),
+                    ar.Plot(fig8b.update_layout(modebar=CONFIG), label="Observations' content in GO terms (barplot version)"),
                     columns=2,
                 ),
             ]
         ),
 
         # Page 4 : dataframes of default summary statistics
-        dp.Page(
+        ar.Page(
             title="Data summary", 
             blocks=[
-                dp.Group(
-                    dp.BigNumber(heading="Number of inputs", value=DATA["N_IN"]),
-                    dp.BigNumber(heading="Kept by EsMeCaTa", value=DATA["N_OUT"]),
-                    dp.BigNumber(heading="Discarded", value=DATA["N_DISCARDED"]),
+                ar.Group(
+                    ar.BigNumber(heading="Number of inputs", value=DATA["N_IN"]),
+                    ar.BigNumber(heading="Kept by EsMeCaTa", value=DATA["N_OUT"]),
+                    ar.BigNumber(heading="Discarded", value=DATA["N_DISCARDED"]),
                     columns=3,
                 ),
 
-                dp.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>"),
-                dp.DataTable(DATA["DF_STATS"], label="Data"),
-                dp.HTML("<h2>Discarded</h2><p>Taxonomic ranks were not inferred; only names are displayed</p>"),
+                ar.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>"),
+                ar.DataTable(DATA["DF_STATS"], label="Data"),
+                ar.HTML("<h2>Discarded</h2><p>Taxonomic ranks were not inferred; only names are displayed</p>"),
                 df_discarded_panel_content
             ]
         ),
 
         # Page 5 : metadata with tools versions, files paths (...) for reproducibility
-        dp.Page(title="Metadata", blocks=[dp.Code(code=metadata, language="json", label="Metadata")]),
+        ar.Page(title="Metadata", blocks=[ar.Code(code=metadata, language="json", label="Metadata")]),
     )
 
-    dp.save_report(report, 
+    ar.save_report(report, 
         path=output_file,
-        formatting=dp.Formatting(
+        formatting=ar.Formatting(
             accent_color="rgb(204, 255, 204)",
-            font=dp.FontChoice.MONOSPACE,
-            width=dp.Width.FULL
-        )
+            font=ar.FontChoice.MONOSPACE,
+            width=ar.Width.FULL
+        ),
+        standalone=True
     )
 
 def create_esmecata_report(esmecata_input_file, esmecata_core_output_folder, output_folder, create_svg=False):
@@ -496,6 +497,6 @@ def create_esmecata_report(esmecata_input_file, esmecata_core_output_folder, out
                             fig12, fig12_details, metadata, esmecata_summary_panel, True)
     """
     esmecata_summary = os.path.join(output_folder, 'esmecata_summary.html')
-    create_datapane_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
+    create_arakawa_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
                             fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
                             fig12, fig12_details, metadata, esmecata_summary)

--- a/esmecata/report/report_creation.py
+++ b/esmecata/report/report_creation.py
@@ -162,7 +162,7 @@ def create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig
                     pn.indicators.Number(name="Discarded", value=DATA["N_DISCARDED"], format='{value}'),
                 ),
                 pn.FlexBox(
-                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>", styles=styles),
+                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete4</p>", styles=styles),
                     pn.pane.DataFrame(DATA["DF_STATS"]),
                 ),
                 pn.FlexBox(
@@ -329,7 +329,7 @@ def create_datapane_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, 
                     columns=3,
                 ),
 
-                dp.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>"),
+                dp.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete4</p>"),
                 dp.DataTable(DATA["DF_STATS"], label="Data"),
                 dp.HTML("<h2>Discarded</h2><p>Taxonomic ranks were not inferred; only names are displayed</p>"),
                 df_discarded_panel_content

--- a/esmecata/report/report_creation.py
+++ b/esmecata/report/report_creation.py
@@ -27,178 +27,35 @@ from esmecata.report.esmecata2taxontology import esmecata2taxonomy
 from esmecata.report.esmecata_compression import esmecata_compression, create_proteomes_barplot
 
 
-def create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
-                        fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
-                        fig12, fig12_details, metadata, output_file, reduce=None):
-    from bokeh.resources import INLINE, CDN
-    import panel as pn
-
-    styles = {
-        'background-color': '#F6F6F6', 'border': '2px solid black',
-        'border-radius': '5px', 'padding': '10px'
-    }
-
-    page_one = pn.Column(
-        pn.pane.Markdown("""# Reduction of taxonomic diversity between EsMeCaTa's inputs and outputs
-                    The sunburst below displays the taxonomic diversity of inputs, i.e. all the taxonomic affiliations listed in the tsv input file. White cells indicates inputs whose ranks were not retained by EsMeCaTa, which went up to the superior taxonomic rank to find proteomes.""",
-                    styles=styles, renderer='markdown'),
-        pn.Column('## Sunburst of taxon selected by EsMeCaTa',
-            pn.pane.Plotly(fig9.update_layout(autosize=True)),
-            sizing_mode='scale_both'),
-
-        pn.pane.Markdown("""# \"Compression\" of taxonomic diversity between inputs and outputs
-                    The sankey diagram below also displays the initial taxonomic diversity of taxonomic affiliations given to EsMeCaTa as inputs. The first column details the content of the input file : one block is equivalent to one taxonomic affiliation, and the block height indicates the number of times this affiliation appears in the input file. The second column details which of these taxonomic affiliations were merged together (i.e. 'compressed') because their taxonomyies were identical in the input file. Finally, The first column displays the ranks EsMeCaTa attributed to each of them : at this step, some taxonomic affiliations can be merged because EsMeCaTa went up the taxonomic ranks to find proteomes.""", styles=styles),
-        pn.Column('## Sankey diagram of taxonomic compression',
-            pn.pane.Plotly(fig10.update_layout(autosize=True)),
-            sizing_mode='scale_both'),
-    )
-    page_two = pn.Column(
-        pn.pane.Markdown("""# Proteomes summary
-                     When proteomes of the lowest taxonomic rank of an input taxa are not found, EsMeCaTa goes up in the taxonomic levels to found suited proteomes. In complement to the figures in the first panel, the heatmap below details the difference between the lowest taxonomic rank of all input taxonomic observations (y-axis) and the lowest rank atributed by EsMeCaTa (x-axis).""", styles=styles),
-        pn.Column('## Input and output ranks difference',
-            pn.pane.Plotly(fig4.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-        pn.pane.HTML("""<p>The barplot belows details how many proteomes were assigned to inputs taxonomic affiliations (grouped and colored by phylum). The number of proteomes found can vary from only a few to dozens or hundreds, depending on the data available on UniProt for each taxonomic group.</p>""", styles=styles),
-        pn.Column('## Distribution of the number of proteomes found',
-            pn.pane.Plotly(fig1.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-        pn.Column('## Distribution of proteomes according to taxonomic ranks',
-            pn.pane.Plotly(fig10a.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-    )
-    page_three = pn.Column(
-            pn.pane.HTML("""<h2>Clustering summary</h2>
-                         <p>In the clustering step, for the set of proteomes associated to each input taxa, EsMeCaTa searches for clusters of similar proteic sequences among these proteomes. This step is supervised by a threshold between 0 and 1, 1 meaning that a cluster contains sequences from each proteomes, 0.5 meaning that a cluster contains sequences from at least a half of the proteomes (etc). This threshold can then be an approximation of the pan-proteome (0) and the core-proteome (1). Clusters below the threshold are discarded. The figure below displays how many clusters were retained at each threshold value. The vertical red line displays the threshold set dor this run of EsMeCata.</p>""", styles=styles),
-        pn.Column('## Proteomes representativeness',
-            pn.pane.Plotly(fig12.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-        pn.Column('## Proteomes representativeness details',
-            pn.pane.Plotly(fig12_details.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-    )
-    page_four = pn.Column(
-        # EC numbers figures
-        pn.FlexBox(
-            pn.pane.HTML("""<h2>EC numbers frequencies among taxa</h2>
-                        <p>Numbers and figures below detail how EC numbers vary among taxa, i.e. if an EC number is found in many taxa (a generic EC number) or only in very few taxa (a specific EC number).</p>""", styles=styles),
-            pn.indicators.Number(name='EC found in more than 90% of taxa', value=DATA2["n_9_an"], format='{value}'),
-            pn.indicators.Number(name='EC found in less than 10% of taxa', value=DATA2["n_1_an"], format='{value}'),
-            pn.indicators.Number(name='EC found between 10% and 90% of taxa', value=DATA2["n91_an"], format='{value}'),
-        ),
-        pn.Column(
-            pn.Column('## EC numbers frequencies in observations',
-                pn.pane.Plotly(fig5.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-            pn.Column('## EC numbers frequencies in observations (barplot version)',
-                pn.pane.Plotly(fig7.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-        ),
-
-        pn.FlexBox(
-            pn.pane.HTML("""<h2>Taxa content in EC numbers</h2>
-                        <p>Numbers and figures below detail which taxa are annotated with most of the EC numbers of the whole dataset or only a few EC numbers. For instance, taxa with many EC numbers could have bigger genomes or be generalist species.</p>""", styles=styles),
-            pn.indicators.Number(name="Taxa with more than 90% of all the dataset's EC numbers", value=DATA2["n_9_ob"], format='{value}'),
-            pn.indicators.Number(name="Taxa with less than 10% of all the dataset's EC numbers", value=DATA2["n_1_ob"], format='{value}'),
-            pn.indicators.Number(name="Taxa with between 10% and 90% of all the dataset's EC numbers", value=DATA2["n91_ob"], format='{value}'),
-        ),
-        pn.Column(
-            pn.Column('## Taxa content in EC numbers',
-                pn.pane.Plotly(fig6.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-            pn.Column('## Taxa content in EC numbers (barplot version)',
-                pn.pane.Plotly(fig8.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-        ),
-
-        pn.pane.HTML("<h2>EC numbers classes, counts and proportions</h2>", styles=styles),
-        pn.Column('## EC numbers classes, counts and proportions',
-            pn.pane.Plotly(fig11.update_layout(modebar=CONFIG, autosize=True)),
-            sizing_mode='scale_both'),
-
-        # GO terms figures
-        pn.FlexBox(
-            pn.pane.HTML("""<h2>GO terms frequencies among taxa</h2>
-                        <p>Numbers and figures below detail how GO terms vary among taxa, i.e. if a GO term is found in many taxa (a generic GO term) or only in very few taxa (a specific GO term).</p>""", styles=styles),
-            pn.indicators.Number(name="GO terms found in more than 90% of taxa", value=DATA3["n_9_an"], format='{value}'),
-            pn.indicators.Number(name="GO terms found in less than 10% of taxa", value=DATA3["n_1_an"], format='{value}'),
-            pn.indicators.Number(name="GO terms found between 10% and 90% of taxa", value=DATA3["n91_an"], format='{value}'),
-        ),
-        pn.Column(
-            pn.Column('## GO terms frequencies in taxa',
-                pn.pane.Plotly(fig5b.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-            pn.Column('## GO terms frequencies in taxa (barplot version)',
-                pn.pane.Plotly(fig7b.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-        ),
-
-        pn.FlexBox(
-        pn.pane.HTML("""<h2>Taxa content in GO terms</h2>
-                     <p>Numbers and figures below detail which taxa are annotated with most of the GO terms of the whole dataset or only a few Go terms. For instance, taxa with many Go terms could have bigger genomes or be generalist species.</p>""", styles=styles),
-            pn.indicators.Number(name="Taxa with more than 90% of all the dataset's GO terms", value=DATA3["n_9_ob"], format='{value}'),
-            pn.indicators.Number(name="Taxa with less than 10% of all the dataset's GO terms", value=DATA3["n_1_ob"], format='{value}'),
-            pn.indicators.Number(name="Taxa with between 10% and 90% of all the dataset's GO terms", value=DATA3["n91_ob"], format='{value}'),
-        ),
-        pn.Column(
-            pn.Column("## Observations' content in GO terms",
-                pn.pane.Plotly(fig6b.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-            pn.Column("## Observations' content in GO terms (barplot version)",
-                pn.pane.Plotly(fig8b.update_layout(modebar=CONFIG, autosize=True)),
-                sizing_mode='scale_both'),
-        ),
-        height=5000
-    )
-
-    if not DATA["DISCARDED"].empty:    
-        discarded_panel_content_panel = pn.pane.DataFrame(DATA["DISCARDED"])
-    else:
-        discarded_panel_content_panel =  pn.pane.HTML("<p>None of input the taxonomic observations were discarded</p>", styles=styles)
-
-    page_five = pn.Column(
-                pn.FlexBox(
-                    pn.indicators.Number(name="Number of inputs", value=DATA["N_IN"], format='{value}'),
-                    pn.indicators.Number(name="Kept by EsMeCaTa", value=DATA["N_OUT"], format='{value}'),
-                    pn.indicators.Number(name="Discarded", value=DATA["N_DISCARDED"], format='{value}'),
-                ),
-                pn.FlexBox(
-                    pn.pane.HTML("<h2>Output stats</h2><p>Taxonomic ranks are NCBI ranks returned by ete3</p>", styles=styles),
-                    pn.pane.DataFrame(DATA["DF_STATS"]),
-                ),
-                pn.FlexBox(
-                    pn.pane.HTML("<h2>Discarded</h2><p>Taxonomic ranks were not inferred; only names are displayed</p>", styles=styles),
-                    discarded_panel_content_panel
-                ),
-    )
-
-    page_six = pn.Column(
-        pn.pane.JSON(metadata, name="Metadata", depth=-1),
-    )
-
-    tabs = pn.Tabs(("Inputs and outputs ranks comparison", page_one),
-                   ("Proteomes summary", page_two),
-                   ("Clustering summary", page_three),
-                   ("Annotation summary", page_four),
-                   ("Data summary", page_five),
-                   ("Metadata", page_six),
-                   height_policy="fit", sizing_mode="fixed")
-
-    panel = pn.template.VanillaTemplate(
-        title="EsMeCaTa report",
-        main=[tabs],
-        header_color='black',
-        header_background='white'
-    )
- 
-    if reduce is True:
-        panel.save(output_file, resources=CDN)
-    else:
-        panel.save(output_file, resources=INLINE)
-
-
 def create_arakawa_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
                         fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
                         fig12, fig12_details, metadata, output_file):
+    """ Create HTML report using arakawa from plotly figures.
+
+    Args:
+        CONFIG (dict): metadata dictionary for plotly.
+        DATA (dict): gathers all useful data for the analysis of an esmecata run (inputs, summary tables, taxonomy ...)
+        DATA2 (dict): dictionary storing dataframes corresponding to EC number with summary numbers
+        DATA3 (dict): dictionary storing dataframes corresponding to GO terms with summary numbers
+        fig1 (plotly figure): histogram showing the distribution of proteomes according to taxonomic rank
+        fig4 (plotly figure): heatmap showing how many input taxonomic ranks were assigned to the same rank by esmecata and how many were assigned to higher ranks
+        fig5 (plotly figure): scatterplot showing the frequency of each EC in taxa
+        fig5b (plotly figure): scatterplot showing the frequency of each GO Term in taxa
+        fig6 (plotly figure): scatterplot showing the fraction of all EC of the dataset in each taxa
+        fig6b (plotly figure): scatterplot showing the fraction of all GO Term of the dataset in each taxa
+        fig7 (plotly figure): histogram showing how many EC numbers belongs to each taxa of this rank
+        fig7b (plotly figure): histogram showing how many GO Terms belongs to each taxa of this rank
+        fig8 (plotly figure): histogram of the fraction of all ECs of the dataset in each taxa
+        fig8b (plotly figure): histogram of the fraction of all GO Terms of the dataset in each taxa
+        fig9 (plotly figure): sunburst representing the taxonomic variety of taxa in the dataset.
+        fig10 (plotly figure): sankey graph showing compression and taxonomic ranks rearrangement between input and output taxa of an Esmecata run
+        fig10a (plotly figure): barplot showing the number proteomes according to the taxonomic rank
+        fig11 (plotly figure): sunburst summarizing EC numbers categories, counts and proportions for the whole dataset
+        fig12 (plotly figure): scatterplot showing the representativeness ratio and the number of associated protein clusters according to the taxonomic rank
+        fig12_details (plotly figure): scatterplot showing details of the representativeness ratio and the number of associated protein clusters according to each cluster
+        metadata (dict): all metadata of the workflow (made by merging esmecata metadata json from proteomes, clustering and annotation)
+        output_file (str): path to HTML output file
+    """
     print("Formatting summary dataframes")
     if not DATA["DISCARDED"].empty:    
         df_discarded_panel_content = ar.DataTable(DATA["DISCARDED"],label="Data")
@@ -350,8 +207,16 @@ def create_arakawa_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, f
         standalone=True
     )
 
-def create_esmecata_report(esmecata_input_file, esmecata_core_output_folder, output_folder, create_svg=False):
 
+def create_esmecata_report(esmecata_input_file, esmecata_core_output_folder, output_folder, create_svg=False):
+    """ Create esmecata HTML report from esmecata output folder.
+
+    Args:
+        esmecata_input_file (str): path to esmecata input file
+        esmecata_core_output_folder (str): path to esmecata output folder (obtained either with workflow or precomputed commands)
+        output_folder (str): path to output folder containing report files.
+        create_svg (bool): create or no svg files.
+    """
     # ======
     # CONFIG
     # ======
@@ -490,12 +355,6 @@ def create_esmecata_report(esmecata_input_file, esmecata_core_output_folder, out
     # ======
     # Report
     # ======
-    """
-    esmecata_summary_panel = os.path.join(output_folder, 'esmecata_summary_panel.html')
-    create_panel_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
-                            fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,
-                            fig12, fig12_details, metadata, esmecata_summary_panel, True)
-    """
     esmecata_summary = os.path.join(output_folder, 'esmecata_summary.html')
     create_arakawa_report(CONFIG, DATA, DATA2, DATA3, fig1, fig4, fig5, fig5b, fig6, fig6b,
                             fig7, fig7b, fig8, fig8b, fig9, fig10, fig10a, fig11,

--- a/esmecata/report/stats_workflow_figures.py
+++ b/esmecata/report/stats_workflow_figures.py
@@ -21,7 +21,7 @@ import os
 import json
 import numpy as np
 import pandas as pd
-from ete3 import NCBITaxa
+from ete4 import NCBITaxa
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.io import write_json
@@ -109,7 +109,7 @@ def _format_axes(fig):
 
 def _format_taxo(proteome_tax_id):
     '''
-    Recovers the full taxonomic lineage of all OTUs/ASVs analyzed by esMeCaTa by parsing proteome_tax_id.tsv with ete3
+    Recovers the full taxonomic lineage of all OTUs/ASVs analyzed by esMeCaTa by parsing proteome_tax_id.tsv with ete4
 
         Parameters:
             proteome_tax_id (pandas): a DataFrame loaded with the output file proteome_tax_id.tsv of EsMeCaTa proteomes
@@ -133,7 +133,7 @@ def _format_taxo(proteome_tax_id):
     names = {}
     data = {}
 
-    # ete3 to get lineages
+    # ete4 to get lineages
     for index, row in proteome_tax_id.iterrows():
         tmp = ncbi.get_lineage(row['tax_id'])
         ranks[index] = ncbi.get_rank(tmp)
@@ -211,7 +211,7 @@ def post_analysis_config(input_table, results_path):
     proteome_tax_id = proteome_tax_id[proteome_tax_id.index.isin(df_stats.index)]
     proteome_tax_id['n_proteomes'] = proteome_tax_id['proteome'].str.split(pat=',').str.len()
 
-    # Input taxonomy must be formatted ; ete3 is used to find the lineage
+    # Input taxonomy must be formatted ; ete4 is used to find the lineage
     output_taxo = _format_taxo(proteome_tax_id)
     df_stats = df_stats.join(output_taxo)
 
@@ -822,7 +822,7 @@ def ec_sunburst_per_model(ec_classes, output_folder, taxgroup, savefig=True):
     Parameters
         ec_classes (list) : a list of EC numbers
         output_folder (str): path to the output folder
-        taxgroup (int) : an ete3 taxonomic group id
+        taxgroup (int) : an ete4 taxonomic group id
         savefig (bool): if the figure should be saved (in svg format). True by default
 
     Returns:

--- a/esmecata/report/stats_workflow_figures.py
+++ b/esmecata/report/stats_workflow_figures.py
@@ -371,7 +371,7 @@ def taxo_ranks_contribution(proteome_tax_id, results_path, n_bins=10, savefig=Tr
 
 def compare_ranks_in_out(proteome_tax_id, association_taxon_tax_id, output_folder, savefig=True):
     '''
-    Plots a heatmap displaying how many input taxonomic ranks were assigned to the same rank by esmecata and how many were assigned to higher tanks.
+    Plots a heatmap displaying how many input taxonomic ranks were assigned to the same rank by esmecata and how many were assigned to higher ranks.
 
         Parameters:
             proteome_tax_id (pandas): a pandas df loaded with esmecata 'proteome_tax_id.tsv' file, output of post_analysis_config()
@@ -1115,7 +1115,7 @@ def reproducibility_tokens(outdir):
             outdir (str) : path to the results of an EsMeCaTa workflow
 
         Returns:
-            metadata (str) : all metadata of the workflow
+            metadata (dict) : all metadata of the workflow
     '''
     reprometa_proteomes = json.load(open(os.path.join(outdir, '0_proteomes', 'esmecata_metadata_proteomes.json'), 'r'))
     reprometa_clustering = json.load(open(os.path.join(outdir, '1_clustering', 'esmecata_metadata_clustering.json'), 'r'))
@@ -1125,6 +1125,4 @@ def reproducibility_tokens(outdir):
          "clustering": reprometa_clustering,
          "annotation": reprometa_annotation}
     
-    # metadata = json.dumps(metadata, indent=4)
-
     return metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   'matplotlib',
   'pandas',
   'requests',
-  'ete3',
+  'ete4',
   'seaborn',
   'SPARQLWrapper'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Homepage = "https://github.com/AuReMe/esmecata"
 Changelog = "https://github.com/AuReMe/esmecata/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
-ANALYSIS = ['datapane',
+ANALYSIS = ['arakawa',
   'plotly',
   'kaleido',
   'ontosunburst'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   'matplotlib',
   'pandas',
   'requests',
-  'ete4',
   'seaborn',
   'SPARQLWrapper'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 biopython>=1.81
 bioservices>=1.11.2
-ete3>=3.1.2
 matplotlib>=3.6.2
 pandas>=1.3.0
 requests>=2.26.0

--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ Furthermore, it requires `esmecata` and its following dependencies:
 - [ete3](https://pypi.org/project/ete3/).
 - [SPARQLwrapper](https://pypi.org/project/SPARQLWrapper/).
 - [mmseqs2](https://github.com/soedinglab/MMseqs2).
-- [datapane](https://github.com/datapane/datapane).
+- [arakawa](https://github.com/ninoseki/arakawa).
 - [plotly](https://github.com/plotly/plotly.py).
 - [kaleido](https://github.com/plotly/Kaleido)
 - [ontosunburst](https://github.com/AuReMe/Ontology_sunburst).

--- a/test/test_proteomes.py
+++ b/test/test_proteomes.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 
 from collections import OrderedDict, Counter
-from ete3 import NCBITaxa
+from ete4 import NCBITaxa
 
 from esmecata.core.proteomes import taxonomic_affiliation_to_taxon_id, associate_taxon_to_taxon_id, \
                                 disambiguate_taxon, find_proteomes_tax_ids, filter_rank_limit, \

--- a/tutorials/esmecata_method.ipynb
+++ b/tutorials/esmecata_method.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "### From taxonomic affiliations to taxon ID\n",
     "\n",
-    "First EsMeCaTa iterates through the taxonomic affiliations to find the taxon ID (in the NCBI Taxonomy database using ete3) for each taxon name. These taxon IDs will be used to search for proteomes in [UniProt Proteomes database](https://www.uniprot.org/proteomes/)."
+    "First EsMeCaTa iterates through the taxonomic affiliations to find the taxon ID (in the NCBI Taxonomy database using ete4) for each taxon name. These taxon IDs will be used to search for proteomes in [UniProt Proteomes database](https://www.uniprot.org/proteomes/)."
    ]
   },
   {
@@ -50,7 +50,7 @@
    ],
    "source": [
     "from esmecata.core.proteomes import taxonomic_affiliation_to_taxon_id\n",
-    "from ete3 import NCBITaxa\n",
+    "from ete4 import NCBITaxa\n",
     "ncbi = NCBITaxa()\n",
     "\n",
     "taxonomic_affiliation = 'cellular organisms;Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacterales;Erwiniaceae;Buchnera;Buchnera aphidicola'\n",


### PR DESCRIPTION
## Modify

* Replace `datapane` by `arakawa` for HTML report creation in `esmecata_report` (issue #20). Make HTMLs standalone (they are a lot bigger but bo not require internet to display).
* Replace `ete3` by `ete4` as ete3 is no longer maintained (issue #18).